### PR TITLE
feat: support qwen3-vlm dense/moe model convert

### DIFF
--- a/awex/meta/meta_resolver.py
+++ b/awex/meta/meta_resolver.py
@@ -33,6 +33,26 @@ from awex.sharding.rank_info import RankInfo
 logger = logging.getLogger(__name__)
 
 
+def get_num_hidden_layers(hf_config) -> int:
+    """Resolve decoder depth from flat or composite Hugging Face configs."""
+
+    def _get_value(config, name):
+        if isinstance(config, dict):
+            return config.get(name)
+        return getattr(config, name, None)
+
+    num_hidden_layers = _get_value(hf_config, "num_hidden_layers")
+    if num_hidden_layers is None:
+        text_config = _get_value(hf_config, "text_config")
+        num_hidden_layers = _get_value(text_config, "num_hidden_layers")
+    if num_hidden_layers is None:
+        raise AttributeError(
+            "Hugging Face config must define num_hidden_layers either at the "
+            "top level or under text_config"
+        )
+    return int(num_hidden_layers)
+
+
 class ParamMetaResolver(ABC):
     """
     Resolves and reconstructs parameter metadata for a distributed model, including sharding and replica information.
@@ -40,7 +60,7 @@ class ParamMetaResolver(ABC):
 
     def __init__(self, hf_config):
         self.hf_config = hf_config
-        self.num_hidden_layers = hf_config.num_hidden_layers
+        self.num_hidden_layers = get_num_hidden_layers(hf_config)
 
     @abstractmethod
     def get_model_arch_name(self) -> str:

--- a/awex/meta/train_meta_resolver.py
+++ b/awex/meta/train_meta_resolver.py
@@ -23,7 +23,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from torch import distributed as dist
 from transformers import PretrainedConfig
 
-from awex.meta.meta_resolver import ParamMetaResolver, logger
+from awex.meta.meta_resolver import (
+    ParamMetaResolver,
+    get_num_hidden_layers,
+    logger,
+)
 from awex.meta.weight_meta import (
     ParameterMeta,
     compute_total_model_size,
@@ -62,7 +66,7 @@ class McoreParamMetaResolver(ParamMetaResolver):
         rank = self._rank_info.global_rank
         self._infer_conf = infer_conf
         self.infer_hf_config = infer_conf["hf_config"]
-        self.num_hidden_layers = self.infer_hf_config.num_hidden_layers
+        self.num_hidden_layers = get_num_hidden_layers(self.infer_hf_config)
         self._pp_stage_layer_id_map: Dict[Tuple[int, int], Dict[int, int]] = {}
         # yyyy_mm_dd_hh_mm_ss
         suffix = (

--- a/awex/models/qwen3_vl.py
+++ b/awex/models/qwen3_vl.py
@@ -1,0 +1,326 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Qwen3-VL dense and MoE weight conversion support."""
+
+import re
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+
+import torch
+
+from awex.models.qwen3_moe import (
+    SGlangToHFWeightConverterQwen3Moe,
+    _build_mcore_converter_qwen3_moe,
+)
+from awex.sharding.param_sharding import (
+    ShardingStrategy,
+    ShardingType,
+    get_default_sharding_dim,
+)
+
+
+def _config_value(config: Any, name: str, default: Any = None) -> Any:
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def get_qwen3_vl_text_config(config: Any) -> Any:
+    """Return the text sub-config from a composite Qwen3-VL config."""
+    return _config_value(config, "text_config", config)
+
+
+def _uses_tied_embeddings(config: Any) -> bool:
+    return bool(
+        _config_value(get_qwen3_vl_text_config(config), "tie_word_embeddings", False)
+    )
+
+
+class Qwen3VLShardingStrategy(ShardingStrategy):
+    """Describe the SGLang/Megatron TP layout of Qwen3-VL vision weights."""
+
+    def _vision_tp_strategy(self, sharding_dim: int):
+        if self.enable_dp_attention:
+            tp_size = self.rank_info.attn_tp_size
+            sharding_type = ShardingType.DP_TP_SHARDING
+        else:
+            tp_size = self.rank_info.tp_size
+            sharding_type = ShardingType.TP_SHARDING
+        if tp_size > 1:
+            return sharding_type, sharding_dim, tp_size
+        return ShardingType.NO_SHARDING, sharding_dim, 1
+
+    def get_sharding_strategy(self, parameter_name: str, **kwargs):
+        if not parameter_name.startswith("model.visual."):
+            return super().get_sharding_strategy(parameter_name, **kwargs)
+
+        sharding_dim = get_default_sharding_dim(parameter_name)
+        replicated_suffixes = (
+            ".bias",
+            ".norm.weight",
+            ".norm.bias",
+            ".norm1.weight",
+            ".norm1.bias",
+            ".norm2.weight",
+            ".norm2.bias",
+        )
+        if parameter_name.startswith("model.visual.patch_embed.") or (
+            parameter_name.endswith(replicated_suffixes)
+            and not parameter_name.endswith(("qkv.bias", "linear_fc1.bias"))
+        ):
+            return ShardingType.NO_SHARDING, sharding_dim, 1
+
+        if parameter_name.endswith("pos_embed.weight"):
+            # MBridge replicates the learned position embedding, while SGLang
+            # partitions its runtime embedding table across vision TP ranks.
+            if self.engine_name == "mcore":
+                return ShardingType.NO_SHARDING, 0, 1
+            return self._vision_tp_strategy(0)
+
+        if parameter_name.endswith(
+            (
+                "attn.qkv.weight",
+                "attn.qkv.bias",
+                "mlp.linear_fc1.weight",
+                "mlp.linear_fc1.bias",
+                "merger.linear_fc1.weight",
+                "merger.linear_fc1.bias",
+            )
+        ) or (
+            ".deepstack_merger_list." in parameter_name
+            and parameter_name.endswith(("linear_fc1.weight", "linear_fc1.bias"))
+        ):
+            return self._vision_tp_strategy(0)
+
+        if parameter_name.endswith(
+            (
+                "attn.proj.weight",
+                "mlp.linear_fc2.weight",
+                "merger.linear_fc2.weight",
+            )
+        ) or (
+            ".deepstack_merger_list." in parameter_name
+            and parameter_name.endswith("linear_fc2.weight")
+        ):
+            return self._vision_tp_strategy(1)
+
+        return ShardingType.NO_SHARDING, sharding_dim, 1
+
+
+class Qwen3VLSGlangToHFWeightConverter(SGlangToHFWeightConverterQwen3Moe):
+    """Reuse Qwen3 text conversion and add Qwen3-VL canonical namespaces."""
+
+    def __init__(self, model_config, infer_engine_config, rank_info):
+        self.vl_model_config = model_config
+        super().__init__(
+            get_qwen3_vl_text_config(model_config), infer_engine_config, rank_info
+        )
+
+    @torch.no_grad()
+    def convert_param(
+        self, name: str, parameter: torch.Tensor
+    ) -> List[Tuple[str, torch.Tensor]]:
+        if name.startswith("visual."):
+            hf_name = f"model.{name}".replace(".attn.qkv_proj.", ".attn.qkv.")
+            return [(hf_name, parameter)]
+
+        converted = []
+        for hf_name, hf_param in super().convert_param(name, parameter):
+            if hf_name.startswith("model."):
+                hf_name = hf_name.replace("model.", "model.language_model.", 1)
+            converted.append((hf_name, hf_param))
+
+        if name == "model.embed_tokens.weight" and _uses_tied_embeddings(
+            self.vl_model_config
+        ):
+            converted.append(("lm_head.weight", parameter))
+        return converted
+
+
+_VISION_LAYER_PATTERN = re.compile(
+    r"vision_model\.decoder\.layers\.(\d+)\.(.+)"
+)
+_VISION_DEEPSTACK_PATTERN = re.compile(
+    r"vision_model\.decoder\.deepstack_merger_list\.(\d+)\.(.+)"
+)
+_VISION_DIRECT_NAMES = {
+    "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+    "vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+    "vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
+    "vision_model.merger.patch_norm.weight": "model.visual.merger.norm.weight",
+    "vision_model.merger.patch_norm.bias": "model.visual.merger.norm.bias",
+    "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+    "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+    "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+    "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+}
+
+
+def _build_mcore_converter_qwen3_vl():
+    # Keep Megatron imports lazy so inference-only workers do not apply patches.
+    qwen3_mcore_converter = _build_mcore_converter_qwen3_moe()
+
+    class Qwen3VLMcoreToHFWeightConverter(qwen3_mcore_converter):
+        """Extend the Qwen3 converter with vision-tower parameter mappings."""
+
+        def __init__(self, hf_config, rank_info, infer_conf, tf_config):
+            self.vl_hf_config = hf_config
+            super().__init__(
+                get_qwen3_vl_text_config(hf_config),
+                rank_info,
+                infer_conf,
+                tf_config,
+            )
+
+        def _convert_vision_qkv(
+            self, layer_number: str, name: str, parameter: torch.Tensor
+        ) -> List[Tuple[str, torch.Tensor]]:
+            from awex.converter.mcore_converter import (
+                convert_qkv_bias_along_tp_attention,
+                convert_qkv_weight_along_tp_attention,
+            )
+
+            vision_config = _config_value(self.vl_hf_config, "vision_config")
+            num_heads = _config_value(vision_config, "num_heads")
+            hidden_size = _config_value(vision_config, "hidden_size")
+            if num_heads is None or hidden_size is None:
+                raise ValueError(
+                    "Qwen3-VL vision_config.num_heads and hidden_size are required "
+                    "for vision QKV conversion"
+                )
+            if int(hidden_size) % int(num_heads) != 0:
+                raise ValueError(
+                    "Qwen3-VL vision hidden_size must be divisible by num_heads: "
+                    f"hidden_size={hidden_size}, num_heads={num_heads}"
+                )
+
+            vision_tf_config = SimpleNamespace(
+                hidden_size=int(hidden_size),
+                num_attention_heads=int(num_heads),
+                num_query_groups=int(num_heads),
+                kv_channels=int(hidden_size) // int(num_heads),
+            )
+            converter = (
+                convert_qkv_weight_along_tp_attention
+                if name.endswith("weight")
+                else convert_qkv_bias_along_tp_attention
+            )
+            packed = converter(
+                parameter,
+                self.infer_atten_tp_size,
+                vision_tf_config,
+                train_tp_rank=int(self.rank_info.attn_tp_rank),
+                train_tp_size=max(1, int(self.rank_info.attn_tp_size)),
+            )
+            kind = "weight" if name.endswith("weight") else "bias"
+            return [(f"model.visual.blocks.{layer_number}.attn.qkv.{kind}", packed)]
+
+        def _convert_vision_param(
+            self, name: str, parameter: torch.Tensor
+        ) -> List[Tuple[str, torch.Tensor]]:
+            if name in _VISION_DIRECT_NAMES:
+                return [(_VISION_DIRECT_NAMES[name], parameter)]
+
+            match = _VISION_LAYER_PATTERN.fullmatch(name)
+            if match is not None:
+                layer_number, remaining_name = match.groups()
+                base = f"model.visual.blocks.{layer_number}"
+                if remaining_name in (
+                    "self_attention.linear_qkv.weight",
+                    "self_attention.linear_qkv.bias",
+                ):
+                    return self._convert_vision_qkv(
+                        layer_number, remaining_name, parameter
+                    )
+                layer_names = {
+                    "self_attention.linear_proj.weight": "attn.proj.weight",
+                    "self_attention.linear_proj.bias": "attn.proj.bias",
+                    "self_attention.linear_qkv.layer_norm_weight": "norm1.weight",
+                    "self_attention.linear_qkv.layer_norm_bias": "norm1.bias",
+                    "mlp.linear_fc1.weight": "mlp.linear_fc1.weight",
+                    "mlp.linear_fc1.bias": "mlp.linear_fc1.bias",
+                    "mlp.linear_fc2.weight": "mlp.linear_fc2.weight",
+                    "mlp.linear_fc2.bias": "mlp.linear_fc2.bias",
+                    "mlp.linear_fc1.layer_norm_weight": "norm2.weight",
+                    "mlp.linear_fc1.layer_norm_bias": "norm2.bias",
+                }
+                if remaining_name in layer_names:
+                    return [(f"{base}.{layer_names[remaining_name]}", parameter)]
+
+            match = _VISION_DEEPSTACK_PATTERN.fullmatch(name)
+            if match is not None:
+                merger_number, remaining_name = match.groups()
+                merger_names = {
+                    "patch_norm.weight": "norm.weight",
+                    "patch_norm.bias": "norm.bias",
+                    "linear_fc1.weight": "linear_fc1.weight",
+                    "linear_fc1.bias": "linear_fc1.bias",
+                    "linear_fc2.weight": "linear_fc2.weight",
+                    "linear_fc2.bias": "linear_fc2.bias",
+                }
+                if remaining_name in merger_names:
+                    base = f"model.visual.deepstack_merger_list.{merger_number}"
+                    return [(f"{base}.{merger_names[remaining_name]}", parameter)]
+
+            raise ValueError(f"Unknown Qwen3-VL vision parameter: {name}")
+
+        @torch.no_grad()
+        def convert_param(
+            self, name: str, parameter: torch.Tensor, vp_stage: int = None
+        ) -> List[Tuple[str, torch.Tensor]]:
+            name = name.replace("module.", "")
+            if name.startswith("vision_model."):
+                return self._convert_vision_param(name, parameter)
+            if not name.startswith("language_model."):
+                raise ValueError(f"Unknown Qwen3-VL parameter: {name}")
+
+            language_name = name[len("language_model.") :]
+            converted = []
+            for hf_name, hf_param in super().convert_param(
+                language_name, parameter, vp_stage=vp_stage
+            ):
+                if hf_name.startswith("model."):
+                    hf_name = hf_name.replace(
+                        "model.", "model.language_model.", 1
+                    )
+                converted.append((hf_name, hf_param))
+
+            if (
+                language_name == "embedding.word_embeddings.weight"
+                and _uses_tied_embeddings(self.vl_hf_config)
+            ):
+                converted.append(("lm_head.weight", parameter))
+            return converted
+
+    return Qwen3VLMcoreToHFWeightConverter
+
+
+CONFIG = [
+    {
+        "model_name": "Qwen3VLForConditionalGeneration",
+        "sharding_strategy": Qwen3VLShardingStrategy,
+        "mcore_converter": _build_mcore_converter_qwen3_vl,
+        "sglang_converter": Qwen3VLSGlangToHFWeightConverter,
+    },
+    {
+        "model_name": "Qwen3VLMoeForConditionalGeneration",
+        "sharding_strategy": Qwen3VLShardingStrategy,
+        "mcore_converter": _build_mcore_converter_qwen3_vl,
+        "sglang_converter": Qwen3VLSGlangToHFWeightConverter,
+    },
+]

--- a/awex/tests/test_qwen3_vl.py
+++ b/awex/tests/test_qwen3_vl.py
@@ -1,0 +1,421 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""CPU unit tests for Qwen3-VL dense and MoE weight conversion."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from awex.meta.meta_resolver import get_num_hidden_layers
+from awex.models.qwen3_moe import SGlangToHFWeightConverterQwen3Moe
+from awex.models.qwen3_vl import (
+    Qwen3VLSGlangToHFWeightConverter,
+    Qwen3VLShardingStrategy,
+    _build_mcore_converter_qwen3_vl,
+)
+from awex.models.registry import (
+    get_infer_weights_converter,
+    get_sharding_strategy,
+    get_train_weights_converter,
+)
+from awex.sharding.param_sharding import ShardingType
+
+
+@pytest.fixture
+def text_config():
+    return SimpleNamespace(
+        hidden_size=8,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=2,
+        num_experts=4,
+        tie_word_embeddings=False,
+    )
+
+
+@pytest.fixture
+def vl_config(text_config):
+    return SimpleNamespace(
+        architectures=["Qwen3VLForConditionalGeneration"],
+        text_config=text_config,
+        vision_config=SimpleNamespace(num_heads=2, hidden_size=4),
+    )
+
+
+@pytest.fixture
+def tf_config():
+    return SimpleNamespace(
+        hidden_size=8,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=2,
+        num_layers=2,
+    )
+
+
+@pytest.fixture
+def rank_info():
+    return SimpleNamespace(
+        tp_rank=0,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        ep_rank=0,
+        ep_size=1,
+        ep_tp_rank=0,
+        ep_tp_size=1,
+        attn_tp_rank=0,
+        attn_tp_size=1,
+    )
+
+
+@pytest.fixture
+def infer_engine_config():
+    return SimpleNamespace(tp_size=1, ep_size=1, device_backend="cpu")
+
+
+def _make_train_converter(vl_config, rank_info, tf_config, **infer_conf):
+    config = {"infer_atten_tp_size": 1, **infer_conf}
+    converter_class = _build_mcore_converter_qwen3_vl()
+    return converter_class(vl_config, rank_info, config, tf_config)
+
+
+def _make_infer_converter(vl_config, rank_info, infer_engine_config):
+    return Qwen3VLSGlangToHFWeightConverter(
+        vl_config, infer_engine_config, rank_info
+    )
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    ["Qwen3VLForConditionalGeneration", "Qwen3VLMoeForConditionalGeneration"],
+)
+def test_registry_resolves_qwen3_vl_dense_and_moe(
+    architecture, vl_config, rank_info, infer_engine_config
+):
+    vl_config.architectures = [architecture]
+
+    converter = get_infer_weights_converter(
+        "sglang",
+        architecture,
+        vl_config,
+        rank_info,
+        infer_engine_config,
+    )
+
+    assert isinstance(converter, Qwen3VLSGlangToHFWeightConverter)
+    assert issubclass(
+        Qwen3VLSGlangToHFWeightConverter, SGlangToHFWeightConverterQwen3Moe
+    )
+    assert get_sharding_strategy(architecture) is Qwen3VLShardingStrategy
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (SimpleNamespace(num_hidden_layers=12), 12),
+        (SimpleNamespace(text_config=SimpleNamespace(num_hidden_layers=28)), 28),
+        ({"text_config": {"num_hidden_layers": 48}}, 48),
+    ],
+)
+def test_num_hidden_layers_supports_flat_and_composite_configs(config, expected):
+    assert get_num_hidden_layers(config) == expected
+
+
+def test_num_hidden_layers_rejects_missing_decoder_depth():
+    with pytest.raises(AttributeError, match="num_hidden_layers"):
+        get_num_hidden_layers(SimpleNamespace(vision_config=SimpleNamespace()))
+
+
+def test_language_qkv_has_train_infer_name_and_value_parity(
+    vl_config, tf_config, rank_info, infer_engine_config
+):
+    train_converter = _make_train_converter(
+        vl_config, rank_info, tf_config, router_dtype="fp32"
+    )
+    infer_converter = _make_infer_converter(
+        vl_config, rank_info, infer_engine_config
+    )
+    mcore_qkv = torch.arange(16 * 8, dtype=torch.float32).reshape(16, 8)
+
+    train_params = train_converter.convert_param(
+        "module.module.language_model.decoder.layers.0."
+        "self_attention.linear_qkv.weight",
+        mcore_qkv,
+    )
+    sglang_qkv = torch.cat([parameter for _, parameter in train_params], dim=0)
+    infer_params = infer_converter.convert_param(
+        "model.layers.0.self_attn.qkv_proj.weight", sglang_qkv
+    )
+
+    expected_names = [
+        "model.language_model.layers.0.self_attn.q_proj.weight",
+        "model.language_model.layers.0.self_attn.k_proj.weight",
+        "model.language_model.layers.0.self_attn.v_proj.weight",
+    ]
+    assert [name for name, _ in train_params] == expected_names
+    assert [name for name, _ in infer_params] == expected_names
+    for (_, train_param), (_, infer_param) in zip(train_params, infer_params):
+        torch.testing.assert_close(train_param, infer_param, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("kind", ["weight", "bias"])
+def test_vision_qkv_tp2_matches_sglang_rank_layout(
+    kind, vl_config, tf_config, rank_info, monkeypatch
+):
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor",
+        lambda parameter, dim=0: parameter,
+    )
+    converter = _make_train_converter(
+        vl_config, rank_info, tf_config, infer_atten_tp_size=2
+    )
+    tail_shape = (4,) if kind == "weight" else ()
+    q = [torch.full((2, *tail_shape), 10 + head) for head in range(2)]
+    k = [torch.full((2, *tail_shape), 20 + head) for head in range(2)]
+    v = [torch.full((2, *tail_shape), 30 + head) for head in range(2)]
+    mcore_qkv = torch.cat(
+        [torch.cat((q[head], k[head], v[head]), dim=0) for head in range(2)],
+        dim=0,
+    )
+
+    [(name, packed_qkv)] = converter.convert_param(
+        "module.module.vision_model.decoder.layers.1."
+        f"self_attention.linear_qkv.{kind}",
+        mcore_qkv,
+    )
+
+    assert name == f"model.visual.blocks.1.attn.qkv.{kind}"
+    for rank, rank_shard in enumerate(torch.chunk(packed_qkv, 2, dim=0)):
+        expected = torch.cat((q[rank], k[rank], v[rank]), dim=0)
+        torch.testing.assert_close(rank_shard, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("mcore_name", "sglang_name", "canonical_name"),
+    [
+        (
+            "module.module.vision_model.patch_embed.proj.weight",
+            "visual.patch_embed.proj.weight",
+            "model.visual.patch_embed.proj.weight",
+        ),
+        (
+            "module.module.vision_model.decoder.layers.1.mlp.linear_fc1.weight",
+            "visual.blocks.1.mlp.linear_fc1.weight",
+            "model.visual.blocks.1.mlp.linear_fc1.weight",
+        ),
+        (
+            "module.module.vision_model.merger.linear_fc2.weight",
+            "visual.merger.linear_fc2.weight",
+            "model.visual.merger.linear_fc2.weight",
+        ),
+        (
+            "module.module.vision_model.decoder.deepstack_merger_list.2."
+            "patch_norm.weight",
+            "visual.deepstack_merger_list.2.norm.weight",
+            "model.visual.deepstack_merger_list.2.norm.weight",
+        ),
+    ],
+)
+def test_vision_parameters_have_train_infer_parity(
+    mcore_name,
+    sglang_name,
+    canonical_name,
+    vl_config,
+    tf_config,
+    rank_info,
+    infer_engine_config,
+):
+    train_converter = _make_train_converter(vl_config, rank_info, tf_config)
+    infer_converter = _make_infer_converter(
+        vl_config, rank_info, infer_engine_config
+    )
+    parameter = torch.arange(8, dtype=torch.float32)
+
+    train_params = train_converter.convert_param(mcore_name, parameter)
+    infer_params = infer_converter.convert_param(sglang_name, parameter)
+
+    assert [name for name, _ in train_params] == [canonical_name]
+    assert [name for name, _ in infer_params] == [canonical_name]
+    torch.testing.assert_close(train_params[0][1], infer_params[0][1], rtol=0, atol=0)
+
+
+def test_moe_expert_reuses_qwen3_global_ep_numbering(
+    vl_config, tf_config, rank_info
+):
+    rank_info.ep_size = 2
+    rank_info.ep_rank = 1
+    converter = _make_train_converter(vl_config, rank_info, tf_config)
+
+    converted = converter.convert_param(
+        "module.module.language_model.decoder.layers.0."
+        "mlp.experts.linear_fc2.weight0",
+        torch.ones(8, 6),
+    )
+
+    assert converted[0][0] == (
+        "model.language_model.layers.0.mlp.experts.2.down_proj.weight"
+    )
+
+
+def test_tied_embedding_alias_has_train_infer_parity(
+    vl_config, tf_config, rank_info, infer_engine_config
+):
+    vl_config.text_config.tie_word_embeddings = True
+    train_converter = _make_train_converter(vl_config, rank_info, tf_config)
+    infer_converter = _make_infer_converter(
+        vl_config, rank_info, infer_engine_config
+    )
+    embedding = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+
+    train_params = train_converter.convert_param(
+        "module.module.language_model.embedding.word_embeddings.weight", embedding
+    )
+    infer_params = infer_converter.convert_param(
+        "model.embed_tokens.weight", embedding
+    )
+
+    expected_names = ["model.language_model.embed_tokens.weight", "lm_head.weight"]
+    assert [name for name, _ in train_params] == expected_names
+    assert [name for name, _ in infer_params] == expected_names
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_type", "expected_dim"),
+    [
+        ("model.visual.patch_embed.proj.weight", ShardingType.NO_SHARDING, 0),
+        ("model.visual.blocks.0.attn.qkv.weight", ShardingType.TP_SHARDING, 0),
+        ("model.visual.blocks.0.attn.proj.weight", ShardingType.TP_SHARDING, 1),
+        (
+            "model.visual.deepstack_merger_list.0.linear_fc1.weight",
+            ShardingType.TP_SHARDING,
+            0,
+        ),
+        (
+            "model.visual.deepstack_merger_list.0.linear_fc2.weight",
+            ShardingType.TP_SHARDING,
+            1,
+        ),
+        (
+            "model.visual.deepstack_merger_list.0.linear_fc2.bias",
+            ShardingType.NO_SHARDING,
+            0,
+        ),
+    ],
+)
+def test_vision_sharding_matches_sglang_layout(
+    name, expected_type, expected_dim, rank_info
+):
+    rank_info.tp_size = 2
+    rank_info.attn_tp_size = 2
+    strategy = Qwen3VLShardingStrategy(
+        engine_name="sglang",
+        enable_dp_attention=False,
+        enable_dp_lm_head=False,
+        moe_dense_tp_size=2,
+        tp_size=2,
+        ep_size=1,
+        ep_tp_size=1,
+        rank_info=rank_info,
+        device_backend="cpu",
+    )
+
+    sharding_type, sharding_dim, num_shards = strategy.get_sharding_strategy(name)
+
+    assert sharding_type is expected_type
+    assert sharding_dim == expected_dim
+    assert num_shards == (2 if expected_type is ShardingType.TP_SHARDING else 1)
+
+
+def test_vision_pos_embedding_is_replicated_on_mcore_and_sharded_on_sglang(
+    rank_info,
+):
+    rank_info.tp_size = 2
+    common = {
+        "enable_dp_attention": False,
+        "enable_dp_lm_head": False,
+        "moe_dense_tp_size": 2,
+        "tp_size": 2,
+        "ep_size": 1,
+        "ep_tp_size": 1,
+        "rank_info": rank_info,
+        "device_backend": "cpu",
+    }
+
+    mcore = Qwen3VLShardingStrategy(engine_name="mcore", **common)
+    sglang = Qwen3VLShardingStrategy(engine_name="sglang", **common)
+
+    name = "model.visual.pos_embed.weight"
+    assert mcore.get_sharding_strategy(name) == (ShardingType.NO_SHARDING, 0, 1)
+    assert sglang.get_sharding_strategy(name) == (ShardingType.TP_SHARDING, 0, 2)
+
+
+def test_pipeline_mapping_only_rewrites_language_layers(
+    vl_config, tf_config, rank_info
+):
+    rank_info.pp_rank = 1
+    rank_info.pp_size = 2
+    converter = _make_train_converter(
+        vl_config,
+        rank_info,
+        tf_config,
+        train_pp_stage_layer_id_map={(1, 0): {0: 1}},
+    )
+    language_weight = torch.ones(8, 8)
+    vision_weight = torch.ones(4, 4)
+
+    [(language_name, _)] = converter.convert_param(
+        "module.module.language_model.decoder.layers.0."
+        "self_attention.linear_proj.weight",
+        language_weight,
+    )
+    [(vision_name, _)] = converter.convert_param(
+        "module.module.vision_model.decoder.layers.0."
+        "self_attention.linear_proj.weight",
+        vision_weight,
+    )
+
+    assert language_name == "model.language_model.layers.1.self_attn.o_proj.weight"
+    assert vision_name == "model.visual.blocks.0.attn.proj.weight"
+
+
+def test_registry_builds_train_converter_with_composite_config(
+    vl_config, tf_config, rank_info
+):
+    converter = get_train_weights_converter(
+        "mcore",
+        "Qwen3VLForConditionalGeneration",
+        vl_config,
+        rank_info,
+        {"infer_atten_tp_size": 1},
+        tf_config=tf_config,
+    )
+
+    assert converter.vl_hf_config is vl_config
+    assert converter.hf_config is vl_config.text_config
+
+
+def test_unknown_vision_parameter_fails_fast(vl_config, tf_config, rank_info):
+    converter = _make_train_converter(vl_config, rank_info, tf_config)
+
+    with pytest.raises(ValueError, match="Unknown Qwen3-VL vision parameter"):
+        converter.convert_param(
+            "module.module.vision_model.unknown.weight", torch.ones(2)
+        )


### PR DESCRIPTION
<!--
**Thanks for contributing to Awex.**

**If this is your first time opening a PR on Awex, you can refer to [CONTRIBUTING.md](https://github.com/inclusionAI/asystem-awex/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Awex** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/inclusionAI/asystem-awex/blob/main/CONTRIBUTING.md).
-->

## What does this PR do?

This PR adds end-to-end AWEX colocate support for Qwen3-VL Dense and MoE models.

  It covers the full colocate lifecycle, including:

  - Training and inference weight metadata exchange.
  - Vision tower and language model weight synchronization.
  - Tensor-parallel vision weight handling.
  - Composite Qwen3-VL configuration propagation without flattening text_config and vision_config.

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/inclusionAI/asystem-awex/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
