### PR TITLE
fix(converter): detect SGLang device backend

### DIFF
--- a/awex/converter/sglang_converter.py
+++ b/awex/converter/sglang_converter.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 from typing import List, Tuple
 
 import torch
 from transformers import PretrainedConfig
 
 from awex.converter.weights_converter import append_scale_inv, normalize_scale_inv_name
+from awex.util import device as device_util
 
 
 # all sglang related imports must be local imports to avoid import error if
@@ -62,12 +62,7 @@ class SGlangToHFWeightConverter:
         comm_backend = self._cfg_value(infer_engine_config, "comm_backend", None)
         if isinstance(comm_backend, str) and comm_backend.strip().lower() == "hccl":
             return "npu"
-        env_backend = os.environ.get("AWEX_DEVICE_TYPE", "").strip().lower()
-        if env_backend in {"cuda", "npu", "cpu"}:
-            return env_backend
-        if os.environ.get("ASCEND_RT_VISIBLE_DEVICES"):
-            return "npu"
-        return "cuda"
+        return device_util.get_device_type()
 
     def _use_transposed_moe_layout(self, name: str, parameter: torch.Tensor) -> bool:
         if self.device_backend != "npu" or parameter.ndim != 2:

--- a/awex/tests/test_qwen3_moe_sglang_converter.py
+++ b/awex/tests/test_qwen3_moe_sglang_converter.py
@@ -30,6 +30,7 @@ import torch
 
 from awex.models.qwen3_moe import SGlangToHFWeightConverterQwen3Moe
 from awex.models.registry import get_infer_weights_converter
+from awex.util import device as device_util
 
 # Tiny Qwen3-MoE-like geometry: GQA with 8 query heads and 2 KV heads.
 NUM_HEADS = 8
@@ -65,6 +66,21 @@ def _make_converter(tp_size=1, ep_size=1, tp_rank=0, ep_rank=0):
         _infer_engine_config(tp_size=tp_size, ep_size=ep_size),
         _rank_info(tp_rank=tp_rank, ep_rank=ep_rank),
     )
+
+
+def test_backend_uses_available_cuda_when_visibility_envs_overlap(monkeypatch):
+    monkeypatch.delenv("AWEX_DEVICE_TYPE", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    monkeypatch.setenv("ASCEND_RT_VISIBLE_DEVICES", "0")
+    monkeypatch.setattr(device_util, "is_npu_available", lambda: False)
+    monkeypatch.setattr(device_util, "is_cuda_available", lambda: True)
+    infer_engine_config = SimpleNamespace(tp_size=1, ep_size=1)
+
+    converter = SGlangToHFWeightConverterQwen3Moe(
+        _model_config(), infer_engine_config, _rank_info()
+    )
+
+    assert converter.device_backend == "cuda"
 
 
 def _sglang_named_params(num_local_experts=NUM_EXPERTS):


### PR DESCRIPTION
## What does this PR do?

This PR makes the SGLang weight converter use AWEX's shared runtime device
detection instead of inferring the device backend from visibility environment
variables.

Explicit `device_backend`/`device_type` configuration and the HCCL backend
continue to take precedence. When they are absent, the converter now delegates
to `device_util.get_device_type()`.

Some launchers export both `CUDA_VISIBLE_DEVICES` and
`ASCEND_RT_VISIBLE_DEVICES`. Previously, the presence of the Ascend variable
caused a CUDA process to be misclassified as NPU, which could incorrectly apply
NPU-specific weight conversion behavior.

A regression test covers the case where both visibility variables are present
while CUDA is the available runtime device.

## Related issues

None.

## Does this PR introduce any user-facing change?

No public API or binary protocol changes. Device backend selection now reflects
the configured or actually available runtime device instead of relying on
visibility environment variables.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Validation

- `ruff check awex/converter/sglang_converter.py awex/tests/test_qwen3_moe_sglang_converter.py`
- `ruff format --check awex/converter/sglang_converter.py awex/tests/test_qwen3_moe_sglang_converter.py`
- `pytest awex/tests/test_qwen3_moe_sglang_converter.py awex/tests/test_qwen3_dense_sglang_converter.py awex/tests/test_meta_resolver.py awex/tests/test_model_registry.py -q`
  - 30 passed
  - 2 skipped
