### PR TITLE
fix(converter): lay out fused MLA a_proj for inference TP

### DIFF
--- a/awex/converter/mcore_converter.py
+++ b/awex/converter/mcore_converter.py
@@ -841,20 +841,24 @@ class LinearMLAMcoreConverterMixin:
         if other_key not in layer_cache:
             return []
 
-        # LinearMLAShardingMixin.get_sharding_strategy() always declares
-        # ``attention.fused_qkv_a_proj_with_mqa.weight`` as NO_SHARDING, so the
-        # transfer plan ships the converted tensor UNCUT to every SGLang TP
-        # rank. The receiver's load_weights layout is the plain concatenation
-        # ``torch.cat([q_a, kv_a], dim=0)``; any infer-TP interleaved layout
-        # ([q_0;kv_0;q_1;kv_1;...]) scrambles
-        # rows for every recipient. Both inputs were already gathered to full
-        # tensors via get_full_tensor above, so the canonical concat is correct
-        # regardless of the train attn-TP size. Keep it unconditional unless
-        # the sharding metadata and transfer plan are changed to perform a
-        # real TP split of this parameter.
-        fused_tensor = torch.cat(
-            [layer_cache["q_a_proj"], layer_cache["kv_a_proj"]], dim=0
-        )
+        # SGLang consumes this parameter per TP rank as [q_i ; kv_i]. With
+        # train attention TP the writer emits a tensor that AWEX chunks on
+        # dim 0, so it has to be laid out [q_0;kv_0;q_1;kv_1;...] or each rank
+        # receives a slice straddling q and kv. Without train attention TP the
+        # tensor reaches every rank uncut and must match SGLang's own
+        # load_weights layout, the plain concatenation. Both layouts have the
+        # same shape, so choosing wrong corrupts attention silently instead of
+        # raising.
+        if self.rank_info.attn_tp_size == 1:
+            fused_tensor = torch.cat(
+                [layer_cache["q_a_proj"], layer_cache["kv_a_proj"]], dim=0
+            )
+        else:
+            fused_tensor = pack_fused_qkv_a_proj_for_tp(
+                layer_cache["q_a_proj"],
+                layer_cache["kv_a_proj"],
+                self.infer_atten_tp_size,
+            )
         del self.qkv_a_proj_cache[layer_number]
         return [("attention.fused_qkv_a_proj_with_mqa.weight", fused_tensor)]
 
@@ -985,6 +989,52 @@ class LinearMLAMcoreConverterMixin:
             return self._post_process_linear_mla_params(converted)
 
         raise NotImplementedError(f"Unsupported parameter name: {name}")
+
+
+def pack_fused_qkv_a_proj_for_tp(
+    q_proj: torch.Tensor,
+    kv_proj: torch.Tensor,
+    infer_tp_size: int,
+) -> torch.Tensor:
+    """Pack MLA q_a/kv_a full tensors in infer-TP local shard order.
+
+    SGLang's fused MLA parameter is consumed per TP rank as:
+    [q_local_rank_i ; kv_local_rank_i]
+
+    AWEX later applies generic TP chunking on dim 0, so the full writer-side
+    tensor must be laid out as:
+    [q_0 ; kv_0 ; q_1 ; kv_1 ; ...]
+    rather than [q_all ; kv_all].
+    """
+    if infer_tp_size <= 0:
+        raise ValueError(f"infer_tp_size must be positive, got {infer_tp_size}")
+    if q_proj.dim() != 2 or kv_proj.dim() != 2:
+        raise ValueError(
+            "Expected 2D MLA projection weights, got "
+            f"q_proj.dim={q_proj.dim()}, kv_proj.dim={kv_proj.dim()}"
+        )
+    if q_proj.shape[1] != kv_proj.shape[1]:
+        raise ValueError(
+            "MLA q/kv projection input dims must match, got "
+            f"q_proj.shape={tuple(q_proj.shape)}, kv_proj.shape={tuple(kv_proj.shape)}"
+        )
+    if q_proj.shape[0] % infer_tp_size != 0:
+        raise ValueError(
+            "MLA q projection rows must be divisible by infer_tp_size, got "
+            f"rows={q_proj.shape[0]}, infer_tp_size={infer_tp_size}"
+        )
+    if kv_proj.shape[0] % infer_tp_size != 0:
+        raise ValueError(
+            "MLA kv projection rows must be divisible by infer_tp_size, got "
+            f"rows={kv_proj.shape[0]}, infer_tp_size={infer_tp_size}"
+        )
+
+    q_shards = q_proj.chunk(infer_tp_size, dim=0)
+    kv_shards = kv_proj.chunk(infer_tp_size, dim=0)
+    return torch.cat(
+        [torch.cat([q_shards[i], kv_shards[i]], dim=0) for i in range(infer_tp_size)],
+        dim=0,
+    )
 
 
 def get_full_tensor(weight: torch.Tensor, dim: int = 0):

--- a/awex/tests/test_fused_mla_a_proj_layout.py
+++ b/awex/tests/test_fused_mla_a_proj_layout.py
@@ -1,0 +1,112 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+"""Layout contract for the fused MLA a_proj under inference tensor parallelism.
+
+SGLang consumes the fused MLA parameter per TP rank as ``[q_i ; kv_i]``. AWEX
+chunks the writer-side tensor on dim 0, so a plain ``cat([q_all, kv_all])``
+gives rank ``i`` a slice that straddles q and kv instead of the pair it needs.
+The rows are the right shape either way, which is why getting this wrong
+corrupts attention silently rather than raising.
+"""
+
+import pytest
+import torch
+
+from awex.converter.mcore_converter import pack_fused_qkv_a_proj_for_tp
+
+Q_ROWS = 8
+KV_ROWS = 4
+IN_DIM = 3
+
+
+def _q_kv():
+    q = torch.arange(Q_ROWS * IN_DIM, dtype=torch.float32).reshape(Q_ROWS, IN_DIM)
+    kv = -torch.arange(KV_ROWS * IN_DIM, dtype=torch.float32).reshape(KV_ROWS, IN_DIM)
+    return q, kv
+
+
+@pytest.mark.parametrize("infer_tp_size", [1, 2, 4])
+def test_each_rank_dim0_slice_is_its_own_q_kv_pair(infer_tp_size):
+    q, kv = _q_kv()
+
+    packed = pack_fused_qkv_a_proj_for_tp(q, kv, infer_tp_size)
+
+    assert packed.shape == (Q_ROWS + KV_ROWS, IN_DIM)
+    q_shards = q.chunk(infer_tp_size, dim=0)
+    kv_shards = kv.chunk(infer_tp_size, dim=0)
+    for rank, shard in enumerate(packed.chunk(infer_tp_size, dim=0)):
+        expected = torch.cat([q_shards[rank], kv_shards[rank]], dim=0)
+        assert torch.equal(shard, expected), f"rank {rank} slice is not [q_i; kv_i]"
+
+
+def test_single_rank_degenerates_to_the_naive_concat():
+    q, kv = _q_kv()
+
+    packed = pack_fused_qkv_a_proj_for_tp(q, kv, 1)
+
+    assert torch.equal(packed, torch.cat([q, kv], dim=0))
+
+
+def test_multi_rank_layout_differs_from_the_naive_concat():
+    """The whole point: the naive layout is what corrupts attention."""
+    q, kv = _q_kv()
+
+    packed = pack_fused_qkv_a_proj_for_tp(q, kv, 4)
+
+    assert not torch.equal(packed, torch.cat([q, kv], dim=0))
+
+
+def test_packing_is_order_preserving_and_invertible():
+    q, kv = _q_kv()
+    tp = 4
+
+    packed = pack_fused_qkv_a_proj_for_tp(q, kv, tp)
+
+    rebuilt_q, rebuilt_kv = [], []
+    for shard in packed.chunk(tp, dim=0):
+        rebuilt_q.append(shard[: Q_ROWS // tp])
+        rebuilt_kv.append(shard[Q_ROWS // tp :])
+    assert torch.equal(torch.cat(rebuilt_q), q)
+    assert torch.equal(torch.cat(rebuilt_kv), kv)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"infer_tp_size": 0},
+        {"q_rows": 7},
+        {"kv_rows": 3},
+        {"in_dim_mismatch": True},
+        {"one_dim": True},
+    ],
+)
+def test_bad_shapes_raise_instead_of_corrupting(bad):
+    q, kv = _q_kv()
+    tp = 4
+    if bad.get("q_rows"):
+        q = torch.zeros(bad["q_rows"], IN_DIM)
+    if bad.get("kv_rows"):
+        kv = torch.zeros(bad["kv_rows"], IN_DIM)
+    if bad.get("in_dim_mismatch"):
+        kv = torch.zeros(KV_ROWS, IN_DIM + 1)
+    if bad.get("one_dim"):
+        q = torch.zeros(Q_ROWS)
+
+    with pytest.raises(ValueError):
+        pack_fused_qkv_a_proj_for_tp(q, kv, bad.get("infer_tp_size", tp))


### PR DESCRIPTION
## What does this PR do?

Fixes silent weight corruption when converting the fused MLA `a_proj` from
Megatron-Core to SGLang with inference tensor parallelism.

SGLang consumes the fused MLA parameter on each inference TP rank as
`[q_i; kv_i]`. AWEX applies generic TP chunking along dimension 0, but the
converter previously produced the full tensor as `[q_all; kv_all]`. Chunking
that layout does not give each rank its corresponding Q and KV shards.

The incorrect and correct layouts have the same shape, so the transfer can
complete without an error while silently corrupting attention weights. This
causes post-update generations and train/inference log-probabilities to
degrade.

This PR:

- packs the full fused tensor as `[q_0; kv_0; q_1; kv_1; ...]` before
  inference TP chunking;
- preserves the plain `[q; kv]` concatenation when training attention TP is
  disabled and the tensor is delivered uncut;
- validates tensor dimensions and TP divisibility before packing;
- adds coverage for inference TP sizes 1, 2, and 4, layout invertibility, and
  invalid inputs.

Validation:

- `ruff format --check awex/converter/mcore_converter.py awex/tests/test_fused_mla_a_proj_layout.py`
- `ruff check awex/converter/mcore_converter.py awex/tests/test_fused_mla_a_proj_layout.py`
- `pytest -v awex/tests/test_fused_mla_a_proj_layout.py`

## Related issues

N/A

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
