### PR TITLE
feat: Support Qwen3.5/Qwen3.6 models convert

### DIFF
--- a/awex/models/qwen3_5.py
+++ b/awex/models/qwen3_5.py
@@ -418,13 +418,15 @@ class _Qwen3_5McoreConverterFactory:
             """
 
             _vision_direct_mapping = {
-                "vision_model.patch_embed.weight": "model.visual.patch_embed.proj.weight",
-                "vision_model.patch_embed.bias": "model.visual.patch_embed.proj.bias",
-                "vision_model.position_embeddings.weight": "model.visual.pos_embed.weight",
-                "vision_model.ln_post.weight": "model.visual.norm.weight",
-                "vision_model.ln_post.bias": "model.visual.norm.bias",
-                "vision_projection_pre_norm.weight": "model.visual.merger.norm.weight",
-                "vision_projection_pre_norm.bias": "model.visual.merger.norm.bias",
+                "vision_model.patch_embed.proj.weight": "model.visual.patch_embed.proj.weight",
+                "vision_model.patch_embed.proj.bias": "model.visual.patch_embed.proj.bias",
+                "vision_model.pos_embed.weight": "model.visual.pos_embed.weight",
+                "vision_model.merger.patch_norm.weight": "model.visual.merger.norm.weight",
+                "vision_model.merger.patch_norm.bias": "model.visual.merger.norm.bias",
+                "vision_model.merger.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+                "vision_model.merger.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+                "vision_model.merger.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+                "vision_model.merger.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
             }
             _vision_layer_mapping = {
                 "self_attention.linear_qkv.weight": "attn.qkv.weight",
@@ -439,14 +441,6 @@ class _Qwen3_5McoreConverterFactory:
                 "mlp.linear_fc1.bias": "mlp.linear_fc1.bias",
                 "mlp.linear_fc2.weight": "mlp.linear_fc2.weight",
                 "mlp.linear_fc2.bias": "mlp.linear_fc2.bias",
-            }
-            _vision_projection_mapping = {
-                "linear_fc1.layer_norm_weight": "norm.weight",
-                "linear_fc1.layer_norm_bias": "norm.bias",
-                "linear_fc1.weight": "linear_fc1.weight",
-                "linear_fc1.bias": "linear_fc1.bias",
-                "linear_fc2.weight": "linear_fc2.weight",
-                "linear_fc2.bias": "linear_fc2.bias",
             }
 
             def __init__(self, hf_config, rank_info, infer_conf, tf_config):
@@ -597,15 +591,6 @@ class _Qwen3_5McoreConverterFactory:
                             parameter,
                         )
                     ]
-                projection_prefix = "vision_projection.encoder."
-                if name.startswith(projection_prefix):
-                    suffix = name[len(projection_prefix) :]
-                    target_suffix = self._vision_projection_mapping.get(suffix)
-                    if target_suffix is None:
-                        raise NotImplementedError(
-                            f"Unsupported Qwen3.5 vision merger parameter: {name}"
-                        )
-                    return [(f"model.visual.merger.{target_suffix}", parameter)]
                 raise NotImplementedError(
                     f"Unsupported Qwen3.5 vision parameter: {name}"
                 )
@@ -615,9 +600,7 @@ class _Qwen3_5McoreConverterFactory:
                 name = name.replace("module.", "")
                 if name.startswith(("language_model.mtp.", "model.mtp.", "mtp.")):
                     return []
-                if name.startswith("vision_model.") or name.startswith(
-                    "vision_projection"
-                ):
+                if name.startswith("vision_model."):
                     return self._convert_visual_param(name, parameter)
 
                 if name.startswith("language_model."):

--- a/awex/models/qwen3_5.py
+++ b/awex/models/qwen3_5.py
@@ -1,0 +1,668 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Qwen3.5 dense/MoE and multimodal weight-update support.
+
+Qwen3.5 combines Qwen3-style dense or expert MLPs with alternating full
+attention and Gated DeltaNet layers.  Its full-attention query projection also
+contains an output gate, so the Megatron ``linear_qkv`` tensor cannot be
+handled by the ordinary Qwen3 GQA splitter.  This module keeps the existing
+Qwen3 converters as the common path and only specializes the hybrid-attention
+and vision layouts.
+
+The canonical names used by Awex follow the Hugging Face checkpoint namespace:
+``model.language_model.*`` for multimodal text weights and ``model.visual.*``
+for the vision tower.  Checkpoints may also expose top-level ``mtp.*`` weights,
+but RL training does not optimize the draft head, so both converter ingress
+paths deliberately filter those parameters before metadata and communication
+plans are built.  Dense and MoE architectures intentionally share this file;
+the inherited Qwen3 MLP conversion already distinguishes dense,
+routed-expert, and shared-expert parameters from their names.
+"""
+
+from types import SimpleNamespace
+from typing import List, Tuple
+
+import torch
+
+from awex.models.qwen3_moe import (
+    SGlangToHFWeightConverterQwen3Moe,
+    _build_mcore_converter_qwen3_moe,
+)
+from awex.models.qwen3_vl import Qwen3VLShardingStrategy
+from awex.sharding.param_sharding import ShardingType, get_default_sharding_dim
+
+
+class _Qwen3_5Layout:
+    """Tensor-layout operations shared by the train-side converter.
+
+    These methods operate only on tensors and model geometry.  Keeping them in
+    one helper class makes the Qwen3.5-specific packing rules explicit without
+    adding another set of generic converter functions to the package.
+    """
+
+    @staticmethod
+    def text_config(config):
+        """Return the language config from either text-only or VLM config."""
+        return getattr(config, "text_config", config)
+
+    @classmethod
+    def head_dim(cls, config) -> int:
+        """Resolve the explicit Qwen3.5 head width with a safe fallback."""
+        config = cls.text_config(config)
+        value = getattr(config, "head_dim", None)
+        if value:
+            return int(value)
+        return int(config.hidden_size // config.num_attention_heads)
+
+    @staticmethod
+    def split_rows(
+        tensor: torch.Tensor, parts: int, description: str
+    ) -> Tuple[torch.Tensor, ...]:
+        """Split dim 0 evenly and fail with geometry-specific context."""
+        if parts <= 0 or tensor.shape[0] % parts != 0:
+            raise ValueError(
+                f"{description} rows ({tensor.shape[0]}) must be divisible by "
+                f"parallel size ({parts})"
+            )
+        return tuple(torch.chunk(tensor, parts, dim=0))
+
+    @classmethod
+    def pack_output_gated_qkv(
+        cls, parameter: torch.Tensor, config, infer_tp_size: int
+    ) -> torch.Tensor:
+        """Repack Megatron gated GQA into SGLang rank-contiguous QKV blocks.
+
+        Megatron stores one block per KV group as ``[Q, gate, K, V]``.  SGLang
+        stores ``[Q-with-gate, K, V]`` for each inference TP rank and replicates
+        K/V heads when TP is wider than the number of KV heads.  The returned
+        tensor concatenates those rank blocks so Awex can reshard it between
+        arbitrary training and inference TP degrees.
+        """
+        config = cls.text_config(config)
+        num_heads = int(config.num_attention_heads)
+        num_kv_heads = int(config.num_key_value_heads)
+        head_dim = cls.head_dim(config)
+        if num_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"attention heads ({num_heads}) must be divisible by KV heads "
+                f"({num_kv_heads})"
+            )
+        if num_heads % infer_tp_size != 0:
+            raise ValueError(
+                f"attention heads ({num_heads}) must be divisible by inference "
+                f"TP ({infer_tp_size})"
+            )
+
+        queries_per_group = num_heads // num_kv_heads
+        query_rows = queries_per_group * head_dim
+        group_rows = 2 * query_rows + 2 * head_dim
+        expected_rows = num_kv_heads * group_rows
+        if parameter.shape[0] != expected_rows:
+            raise ValueError(
+                "unexpected gated QKV rows: "
+                f"got {parameter.shape[0]}, expected {expected_rows}"
+            )
+
+        tail = parameter.shape[1:]
+        groups = parameter.reshape(num_kv_heads, group_rows, *tail)
+        query = groups[:, :query_rows].reshape(num_heads, head_dim, *tail)
+        gate = groups[:, query_rows : 2 * query_rows].reshape(
+            num_heads, head_dim, *tail
+        )
+        query = torch.cat((query, gate), dim=1)
+        key = groups[:, 2 * query_rows : 2 * query_rows + head_dim].reshape(
+            num_kv_heads, head_dim, *tail
+        )
+        value = groups[:, 2 * query_rows + head_dim :].reshape(
+            num_kv_heads, head_dim, *tail
+        )
+
+        query_shards = cls.split_rows(query, infer_tp_size, "query projection")
+        if infer_tp_size >= num_kv_heads:
+            if infer_tp_size % num_kv_heads != 0:
+                raise ValueError(
+                    f"inference TP ({infer_tp_size}) must be divisible by KV "
+                    f"heads ({num_kv_heads})"
+                )
+            replicas = infer_tp_size // num_kv_heads
+            key_shards = [head for head in key for _ in range(replicas)]
+            value_shards = [head for head in value for _ in range(replicas)]
+        else:
+            if num_kv_heads % infer_tp_size != 0:
+                raise ValueError(
+                    f"KV heads ({num_kv_heads}) must be divisible by inference "
+                    f"TP ({infer_tp_size})"
+                )
+            key_shards = cls.split_rows(key, infer_tp_size, "key projection")
+            value_shards = cls.split_rows(value, infer_tp_size, "value projection")
+
+        blocks = []
+        for query_shard, key_shard, value_shard in zip(
+            query_shards, key_shards, value_shards
+        ):
+            blocks.append(
+                torch.cat(
+                    (
+                        query_shard.reshape(-1, *tail),
+                        key_shard.reshape(-1, *tail),
+                        value_shard.reshape(-1, *tail),
+                    ),
+                    dim=0,
+                )
+            )
+        return torch.cat(blocks, dim=0).contiguous()
+
+    @classmethod
+    def split_gdn_input(
+        cls, parameter: torch.Tensor, config, train_tp_size: int
+    ) -> Tuple[torch.Tensor, ...]:
+        """Undo Megatron's rank-local ``[Q,K,V,Z,B,A]`` GDN packing."""
+        config = cls.text_config(config)
+        qk_dim = int(config.linear_num_key_heads * config.linear_key_head_dim)
+        value_dim = int(config.linear_num_value_heads * config.linear_value_head_dim)
+        value_heads = int(config.linear_num_value_heads)
+        dimensions = (qk_dim, qk_dim, value_dim, value_dim, value_heads, value_heads)
+        if any(size % train_tp_size != 0 for size in dimensions):
+            raise ValueError("GDN input dimensions must be divisible by training TP")
+
+        local_sizes = tuple(size // train_tp_size for size in dimensions)
+        rows_per_rank = sum(local_sizes)
+        if parameter.shape[0] != rows_per_rank * train_tp_size:
+            raise ValueError(
+                "unexpected GDN input rows: "
+                f"got {parameter.shape[0]}, expected {rows_per_rank * train_tp_size}"
+            )
+        rank_blocks = parameter.reshape(
+            train_tp_size, rows_per_rank, *parameter.shape[1:]
+        )
+        pieces = [[] for _ in local_sizes]
+        for rank_block in rank_blocks:
+            for target, piece in zip(
+                pieces, torch.split(rank_block, local_sizes, dim=0)
+            ):
+                target.append(piece)
+        return tuple(torch.cat(part, dim=0) for part in pieces)
+
+    @classmethod
+    def pack_gdn_input(
+        cls,
+        parameter: torch.Tensor,
+        config,
+        train_tp_size: int,
+        infer_tp_size: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Build SGLang's fused QKVZ and BA tensors in inference-rank order."""
+        categories = cls.split_gdn_input(parameter, config, train_tp_size)
+        shards = [
+            cls.split_rows(tensor, infer_tp_size, f"GDN input category {index}")
+            for index, tensor in enumerate(categories)
+        ]
+        qkvz = [
+            torch.cat([shards[index][rank] for index in range(4)], dim=0)
+            for rank in range(infer_tp_size)
+        ]
+        ba = [
+            torch.cat([shards[index][rank] for index in range(4, 6)], dim=0)
+            for rank in range(infer_tp_size)
+        ]
+        return torch.cat(qkvz, dim=0), torch.cat(ba, dim=0)
+
+    @classmethod
+    def pack_gdn_conv(
+        cls,
+        parameter: torch.Tensor,
+        config,
+        train_tp_size: int,
+        infer_tp_size: int,
+    ) -> torch.Tensor:
+        """Reorder Megatron's rank-local Q/K/V convolution channels for SGLang."""
+        config = cls.text_config(config)
+        qk_dim = int(config.linear_num_key_heads * config.linear_key_head_dim)
+        value_dim = int(config.linear_num_value_heads * config.linear_value_head_dim)
+        if qk_dim % train_tp_size or value_dim % train_tp_size:
+            raise ValueError("GDN convolution dimensions must divide training TP")
+        local_qk = qk_dim // train_tp_size
+        local_value = value_dim // train_tp_size
+        rows_per_rank = 2 * local_qk + local_value
+        if parameter.shape[0] != rows_per_rank * train_tp_size:
+            raise ValueError("unexpected GDN convolution rows")
+
+        query_parts, key_parts, value_parts = [], [], []
+        for block in parameter.reshape(
+            train_tp_size, rows_per_rank, *parameter.shape[1:]
+        ):
+            query, key, value = torch.split(
+                block, (local_qk, local_qk, local_value), dim=0
+            )
+            query_parts.append(query)
+            key_parts.append(key)
+            value_parts.append(value)
+        categories = (
+            torch.cat(query_parts),
+            torch.cat(key_parts),
+            torch.cat(value_parts),
+        )
+        shards = [
+            cls.split_rows(tensor, infer_tp_size, f"GDN conv category {index}")
+            for index, tensor in enumerate(categories)
+        ]
+        return torch.cat(
+            [
+                torch.cat([shards[index][rank] for index in range(3)], dim=0)
+                for rank in range(infer_tp_size)
+            ],
+            dim=0,
+        )
+
+
+class Qwen3_5ShardingStrategy(Qwen3VLShardingStrategy):
+    """TP/EP rules for Qwen3.5 language and vision parameters.
+
+    Pipeline parallelism is represented by parameter ownership in Awex rather
+    than another sharding enum, so this class only declares the tensor or expert
+    dimensions within the owning PP stage.  Vision rules come from Qwen3-VL;
+    MTP parameters never reach this strategy because the converters filter
+    them before transfer metadata is constructed.
+    """
+
+    def get_sharding_strategy(self, parameter_name: str, **kwargs):
+        if ".linear_attn." in parameter_name:
+            if ".norm." in parameter_name:
+                return ShardingType.NO_SHARDING, 0, 1
+            sharding_dim = 1 if parameter_name.endswith("out_proj.weight") else 0
+            return self.get_attention_sharding_strategy(
+                parameter_name, sharding_dim=sharding_dim, **kwargs
+            )
+        if ".self_attn." in parameter_name:
+            if "_norm." in parameter_name:
+                return ShardingType.NO_SHARDING, 0, 1
+            return self.get_attention_sharding_strategy(parameter_name, **kwargs)
+        if "shared_expert_gate" in parameter_name:
+            return ShardingType.NO_SHARDING, 0, 1
+        if "shared_expert" in parameter_name:
+            return self.get_shared_expert_sharding_strategy(parameter_name, **kwargs)
+        if ".experts." in parameter_name:
+            # The base strategy returns early when dense TP is one.  EP is an
+            # independent axis and must still describe expert ownership.
+            return self.get_expert_sharding_strategy(parameter_name, **kwargs)
+        return super().get_sharding_strategy(parameter_name, **kwargs)
+
+    def get_attention_sharding_strategy(self, parameter_name, **kwargs):
+        """Honor an explicit hybrid-attention dimension when one is supplied."""
+        explicit_dim = kwargs.pop("sharding_dim", None)
+        if explicit_dim is None:
+            return super().get_attention_sharding_strategy(parameter_name, **kwargs)
+        if self.enable_dp_attention:
+            size = self.rank_info.attn_tp_size
+            kind = ShardingType.DP_TP_SHARDING
+        else:
+            size = self.rank_info.tp_size
+            kind = ShardingType.TP_SHARDING
+        if size <= 1:
+            return ShardingType.NO_SHARDING, explicit_dim, 1
+        return kind, explicit_dim, size
+
+    def get_shared_expert_sharding_strategy(self, parameter_name, **kwargs):
+        """Keep the standalone shared MLP on dense TP rather than routed EP."""
+        sharding_dim = get_default_sharding_dim(parameter_name)
+        if self.tp_size > 1:
+            return ShardingType.TP_SHARDING, sharding_dim, self.tp_size
+        return ShardingType.NO_SHARDING, sharding_dim, 1
+
+
+class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
+    """Normalize current SGLang Qwen3.5 target-model parameters.
+
+    SGLang removes ``self_attn`` from full-attention module names and fuses the
+    gated query/K/V weights into ``qkv_proj``.  The converter restores a stable
+    checkpoint-like namespace while deliberately keeping that fused tensor;
+    the Megatron converter emits the same layout, avoiding a duplicate gated-
+    QKV split/repack path in the transfer planner.
+    """
+
+    def __init__(self, model_config, infer_engine_config, rank_info):
+        self.root_config = model_config
+        self.is_multimodal = hasattr(model_config, "text_config")
+        super().__init__(
+            _Qwen3_5Layout.text_config(model_config),
+            infer_engine_config,
+            rank_info,
+        )
+
+    def _fuse_qkv(self, name: str) -> bool:
+        return True
+
+    @staticmethod
+    def _normalize_shared_expert(name: str) -> str:
+        return name.replace(".shared_experts.", ".shared_expert.")
+
+    def _canonical_main_name(self, name: str) -> str:
+        if self.is_multimodal and name.startswith("model."):
+            return name.replace("model.", "model.language_model.", 1)
+        return name
+
+    @torch.no_grad()
+    def convert_param(
+        self, name: str, parameter: torch.Tensor
+    ) -> List[Tuple[str, torch.Tensor]]:
+        name = name.replace("model.language_model.", "model.")
+        if name.startswith(("mtp.", "model.mtp.")):
+            # MTP is loaded with the inference model but remains frozen during
+            # RL.  Returning no canonical parameters keeps it out of infer
+            # metadata and therefore out of the generated transfer plan.
+            return []
+        if name.startswith("model.visual."):
+            name = name.replace("model.visual.", "visual.", 1)
+        if name.startswith("visual."):
+            name = name.replace(".attn.qkv_proj.", ".attn.qkv.")
+            return [(f"model.{name}", parameter)]
+        parts = name.split(".")
+        if len(parts) >= 5 and parts[:2] == ["model", "layers"]:
+            layer_number = parts[2]
+            remaining_name = ".".join(parts[3:])
+            if remaining_name.startswith(
+                ("qkv_proj.", "o_proj.", "q_norm.", "k_norm.")
+            ):
+                canonical = f"model.layers.{layer_number}.self_attn.{remaining_name}"
+                return [(self._canonical_main_name(canonical), parameter)]
+            if remaining_name.startswith("linear_attn.") or remaining_name.startswith(
+                "mlp.shared_expert_gate."
+            ):
+                canonical = self._normalize_shared_expert(name)
+                return [(self._canonical_main_name(canonical), parameter)]
+
+        converted = []
+        for converted_name, converted_parameter in super().convert_param(
+            name, parameter
+        ):
+            converted_name = self._normalize_shared_expert(converted_name)
+            converted.append(
+                (
+                    self._canonical_main_name(converted_name),
+                    converted_parameter,
+                )
+            )
+        return converted
+
+
+class _Qwen3_5McoreConverterFactory:
+    """Lazily build the Megatron converter without eager Megatron imports."""
+
+    def __call__(self):
+        base_converter = _build_mcore_converter_qwen3_moe()
+
+        class McoreToHFWeightConverterQwen3_5(base_converter):
+            """Convert trainable Megatron Qwen3.5 language and vision weights.
+
+            Decoder PP layer ids continue through the existing Qwen3 converter,
+            and expert id expansion plus EP offsets are inherited from the
+            Qwen3 MoE path.  Megatron checkpoints can expose an ``mtp`` subtree,
+            but RL leaves it frozen; ``convert_param`` returns an empty list for
+            that subtree so it is absent from metadata, transfer planning, and
+            each subsequent update.
+            """
+
+            _vision_direct_mapping = {
+                "vision_model.patch_embed.weight": "model.visual.patch_embed.proj.weight",
+                "vision_model.patch_embed.bias": "model.visual.patch_embed.proj.bias",
+                "vision_model.position_embeddings.weight": "model.visual.pos_embed.weight",
+                "vision_model.ln_post.weight": "model.visual.norm.weight",
+                "vision_model.ln_post.bias": "model.visual.norm.bias",
+                "vision_projection_pre_norm.weight": "model.visual.merger.norm.weight",
+                "vision_projection_pre_norm.bias": "model.visual.merger.norm.bias",
+            }
+            _vision_layer_mapping = {
+                "self_attention.linear_qkv.weight": "attn.qkv.weight",
+                "self_attention.linear_qkv.bias": "attn.qkv.bias",
+                "self_attention.linear_proj.weight": "attn.proj.weight",
+                "self_attention.linear_proj.bias": "attn.proj.bias",
+                "self_attention.linear_qkv.layer_norm_weight": "norm1.weight",
+                "self_attention.linear_qkv.layer_norm_bias": "norm1.bias",
+                "mlp.linear_fc1.layer_norm_weight": "norm2.weight",
+                "mlp.linear_fc1.layer_norm_bias": "norm2.bias",
+                "mlp.linear_fc1.weight": "mlp.linear_fc1.weight",
+                "mlp.linear_fc1.bias": "mlp.linear_fc1.bias",
+                "mlp.linear_fc2.weight": "mlp.linear_fc2.weight",
+                "mlp.linear_fc2.bias": "mlp.linear_fc2.bias",
+            }
+            _vision_projection_mapping = {
+                "linear_fc1.layer_norm_weight": "norm.weight",
+                "linear_fc1.layer_norm_bias": "norm.bias",
+                "linear_fc1.weight": "linear_fc1.weight",
+                "linear_fc1.bias": "linear_fc1.bias",
+                "linear_fc2.weight": "linear_fc2.weight",
+                "linear_fc2.bias": "linear_fc2.bias",
+            }
+
+            def __init__(self, hf_config, rank_info, infer_conf, tf_config):
+                self.root_config = hf_config
+                self.vision_config = getattr(hf_config, "vision_config", None)
+                self.is_multimodal = hasattr(hf_config, "text_config")
+                super().__init__(
+                    _Qwen3_5Layout.text_config(hf_config),
+                    rank_info,
+                    infer_conf,
+                    tf_config=tf_config,
+                )
+
+            def _full_tp_tensor(self, parameter: torch.Tensor) -> torch.Tensor:
+                if int(self.rank_info.attn_tp_size) <= 1:
+                    return parameter
+                from awex.converter.mcore_converter import get_full_tensor
+
+                return get_full_tensor(parameter, dim=0)
+
+            def _take_train_tp_shard(self, parameter: torch.Tensor) -> torch.Tensor:
+                train_tp_size = max(1, int(self.rank_info.attn_tp_size))
+                if train_tp_size == 1:
+                    return parameter
+                shards = _Qwen3_5Layout.split_rows(
+                    parameter, train_tp_size, "converted parameter"
+                )
+                return shards[int(self.rank_info.attn_tp_rank)].contiguous()
+
+            def _convert_attention_param(self, name, parameter, layer_number):
+                train_tp_size = max(1, int(self.rank_info.attn_tp_size))
+                infer_tp_size = max(1, int(self.infer_atten_tp_size))
+                if "self_attention.linear_qkv.weight" in name or (
+                    "self_attention.linear_qkv.bias" in name
+                ):
+                    suffix = "weight" if name.endswith("weight") else "bias"
+                    packed = _Qwen3_5Layout.pack_output_gated_qkv(
+                        self._full_tp_tensor(parameter),
+                        self.hf_config,
+                        infer_tp_size,
+                    )
+                    return [
+                        (
+                            f"self_attn.qkv_proj.{suffix}",
+                            self._take_train_tp_shard(packed),
+                        )
+                    ]
+                if "self_attention.in_proj.layer_norm_weight" in name:
+                    return [("input_layernorm.weight", parameter)]
+                if "self_attention.in_proj.weight" in name:
+                    qkvz, ba = _Qwen3_5Layout.pack_gdn_input(
+                        self._full_tp_tensor(parameter),
+                        self.hf_config,
+                        train_tp_size,
+                        infer_tp_size,
+                    )
+                    return [
+                        (
+                            "linear_attn.in_proj_qkvz.weight",
+                            self._take_train_tp_shard(qkvz),
+                        ),
+                        (
+                            "linear_attn.in_proj_ba.weight",
+                            self._take_train_tp_shard(ba),
+                        ),
+                    ]
+                if "self_attention.conv1d.weight" in name:
+                    packed = _Qwen3_5Layout.pack_gdn_conv(
+                        self._full_tp_tensor(parameter),
+                        self.hf_config,
+                        train_tp_size,
+                        infer_tp_size,
+                    )
+                    return [
+                        (
+                            "linear_attn.conv1d.weight",
+                            self._take_train_tp_shard(packed),
+                        )
+                    ]
+                if "self_attention.out_proj.weight" in name:
+                    return [("linear_attn.out_proj.weight", parameter)]
+                if "self_attention.out_norm.weight" in name:
+                    return [("linear_attn.norm.weight", parameter + 1.0)]
+                if "self_attention.A_log" in name:
+                    return [("linear_attn.A_log", parameter)]
+                if "self_attention.dt_bias" in name:
+                    return [("linear_attn.dt_bias", parameter)]
+                return super()._convert_attention_param(name, parameter, layer_number)
+
+            def _convert_mlp_param(self, name, parameter, layer_number):
+                return [
+                    (
+                        converted_name.replace(".shared_experts.", ".shared_expert."),
+                        converted_parameter,
+                    )
+                    for converted_name, converted_parameter in super()._convert_mlp_param(
+                        name, parameter, layer_number
+                    )
+                ]
+
+            def _convert_visual_param(self, name, parameter):
+                target = self._vision_direct_mapping.get(name)
+                if target is not None:
+                    return [(target, parameter)]
+                layer_prefix = "vision_model.decoder.layers."
+                if name.startswith(layer_prefix):
+                    layer_number, suffix = name[len(layer_prefix) :].split(".", 1)
+                    target_suffix = self._vision_layer_mapping.get(suffix)
+                    if target_suffix is None:
+                        raise NotImplementedError(
+                            f"Unsupported Qwen3.5 vision layer parameter: {name}"
+                        )
+                    if suffix in {
+                        "self_attention.linear_qkv.weight",
+                        "self_attention.linear_qkv.bias",
+                    }:
+                        if self.vision_config is None:
+                            raise ValueError(
+                                "vision_config is required for Qwen3.5 visual QKV"
+                            )
+                        from awex.converter.mcore_converter import (
+                            convert_qkv_bias_along_tp_attention,
+                            convert_qkv_weight_along_tp_attention,
+                        )
+
+                        vision_config = SimpleNamespace(
+                            hidden_size=int(self.vision_config.hidden_size),
+                            num_attention_heads=int(self.vision_config.num_heads),
+                            num_query_groups=int(self.vision_config.num_heads),
+                            kv_channels=int(self.vision_config.hidden_size)
+                            // int(self.vision_config.num_heads),
+                        )
+                        converter = (
+                            convert_qkv_weight_along_tp_attention
+                            if suffix.endswith("weight")
+                            else convert_qkv_bias_along_tp_attention
+                        )
+                        parameter = converter(
+                            parameter,
+                            self.infer_atten_tp_size,
+                            vision_config,
+                            train_tp_rank=int(self.rank_info.attn_tp_rank),
+                            train_tp_size=max(1, int(self.rank_info.attn_tp_size)),
+                        )
+                    return [
+                        (
+                            f"model.visual.blocks.{layer_number}.{target_suffix}",
+                            parameter,
+                        )
+                    ]
+                projection_prefix = "vision_projection.encoder."
+                if name.startswith(projection_prefix):
+                    suffix = name[len(projection_prefix) :]
+                    target_suffix = self._vision_projection_mapping.get(suffix)
+                    if target_suffix is None:
+                        raise NotImplementedError(
+                            f"Unsupported Qwen3.5 vision merger parameter: {name}"
+                        )
+                    return [(f"model.visual.merger.{target_suffix}", parameter)]
+                raise NotImplementedError(
+                    f"Unsupported Qwen3.5 vision parameter: {name}"
+                )
+
+            @torch.no_grad()
+            def convert_param(self, name, parameter, vp_stage=None):
+                name = name.replace("module.", "")
+                if name.startswith(("language_model.mtp.", "model.mtp.", "mtp.")):
+                    return []
+                if name.startswith("vision_model.") or name.startswith(
+                    "vision_projection"
+                ):
+                    return self._convert_visual_param(name, parameter)
+
+                if name.startswith("language_model."):
+                    name = name[len("language_model.") :]
+                converted = super().convert_param(name, parameter, vp_stage=vp_stage)
+                if not self.is_multimodal:
+                    return converted
+                return [
+                    (
+                        converted_name.replace("model.", "model.language_model.", 1)
+                        if converted_name.startswith("model.")
+                        else converted_name,
+                        converted_parameter,
+                    )
+                    for converted_name, converted_parameter in converted
+                ]
+
+        return McoreToHFWeightConverterQwen3_5
+
+
+_MCORE_CONVERTER_FACTORY = _Qwen3_5McoreConverterFactory()
+
+CONFIG = [
+    {
+        "model_name": "Qwen3_5ForCausalLM",
+        "sharding_strategy": Qwen3_5ShardingStrategy,
+        "mcore_converter": _MCORE_CONVERTER_FACTORY,
+        "sglang_converter": SGlangToHFWeightConverterQwen3_5,
+    },
+    {
+        "model_name": "Qwen3_5MoeForCausalLM",
+        "sharding_strategy": Qwen3_5ShardingStrategy,
+        "mcore_converter": _MCORE_CONVERTER_FACTORY,
+        "sglang_converter": SGlangToHFWeightConverterQwen3_5,
+    },
+    {
+        "model_name": "Qwen3_5ForConditionalGeneration",
+        "sharding_strategy": Qwen3_5ShardingStrategy,
+        "mcore_converter": _MCORE_CONVERTER_FACTORY,
+        "sglang_converter": SGlangToHFWeightConverterQwen3_5,
+    },
+    {
+        "model_name": "Qwen3_5MoeForConditionalGeneration",
+        "sharding_strategy": Qwen3_5ShardingStrategy,
+        "mcore_converter": _MCORE_CONVERTER_FACTORY,
+        "sglang_converter": SGlangToHFWeightConverterQwen3_5,
+    },
+]

--- a/awex/models/qwen3_5.py
+++ b/awex/models/qwen3_5.py
@@ -24,14 +24,16 @@ handled by the ordinary Qwen3 GQA splitter.  This module keeps the existing
 Qwen3 converters as the common path and only specializes the hybrid-attention
 and vision layouts.
 
-The canonical names used by Awex follow the Hugging Face checkpoint namespace:
-``model.language_model.*`` for multimodal text weights and ``model.visual.*``
-for the vision tower.  Checkpoints may also expose top-level ``mtp.*`` weights,
-but RL training does not optimize the draft head, so both converter ingress
-paths deliberately filter those parameters before metadata and communication
-plans are built.  Dense and MoE architectures intentionally share this file;
-the inherited Qwen3 MLP conversion already distinguishes dense,
-routed-expert, and shared-expert parameters from their names.
+The canonical names used by Awex are ``model.*`` for language weights and
+``model.visual.*`` for the vision tower.  The language namespace is deliberately
+independent of the Hugging Face VLM wrapper because SGLang may expose either the
+top-level conditional-generation model or its unwrapped causal-LM submodule to
+the weight-update callback.  Checkpoints may also expose top-level ``mtp.*``
+weights, but RL training does not optimize the draft head, so both converter
+ingress paths filter those parameters before metadata and communication plans
+are built.  Dense and MoE architectures intentionally share this file; the
+inherited Qwen3 MLP conversion already distinguishes dense, routed-expert, and
+shared-expert parameters from their names.
 """
 
 from types import SimpleNamespace
@@ -336,8 +338,6 @@ class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
     """
 
     def __init__(self, model_config, infer_engine_config, rank_info):
-        self.root_config = model_config
-        self.is_multimodal = hasattr(model_config, "text_config")
         super().__init__(
             _Qwen3_5Layout.text_config(model_config),
             infer_engine_config,
@@ -350,11 +350,6 @@ class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
     @staticmethod
     def _normalize_shared_expert(name: str) -> str:
         return name.replace(".shared_experts.", ".shared_expert.")
-
-    def _canonical_main_name(self, name: str) -> str:
-        if self.is_multimodal and name.startswith("model."):
-            return name.replace("model.", "model.language_model.", 1)
-        return name
 
     @torch.no_grad()
     def convert_param(
@@ -379,12 +374,12 @@ class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
                 ("qkv_proj.", "o_proj.", "q_norm.", "k_norm.")
             ):
                 canonical = f"model.layers.{layer_number}.self_attn.{remaining_name}"
-                return [(self._canonical_main_name(canonical), parameter)]
+                return [(canonical, parameter)]
             if remaining_name.startswith("linear_attn.") or remaining_name.startswith(
                 "mlp.shared_expert_gate."
             ):
                 canonical = self._normalize_shared_expert(name)
-                return [(self._canonical_main_name(canonical), parameter)]
+                return [(canonical, parameter)]
 
         converted = []
         for converted_name, converted_parameter in super().convert_param(
@@ -393,7 +388,7 @@ class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
             converted_name = self._normalize_shared_expert(converted_name)
             converted.append(
                 (
-                    self._canonical_main_name(converted_name),
+                    converted_name,
                     converted_parameter,
                 )
             )
@@ -446,7 +441,6 @@ class _Qwen3_5McoreConverterFactory:
             def __init__(self, hf_config, rank_info, infer_conf, tf_config):
                 self.root_config = hf_config
                 self.vision_config = getattr(hf_config, "vision_config", None)
-                self.is_multimodal = hasattr(hf_config, "text_config")
                 super().__init__(
                     _Qwen3_5Layout.text_config(hf_config),
                     rank_info,
@@ -605,18 +599,7 @@ class _Qwen3_5McoreConverterFactory:
 
                 if name.startswith("language_model."):
                     name = name[len("language_model.") :]
-                converted = super().convert_param(name, parameter, vp_stage=vp_stage)
-                if not self.is_multimodal:
-                    return converted
-                return [
-                    (
-                        converted_name.replace("model.", "model.language_model.", 1)
-                        if converted_name.startswith("model.")
-                        else converted_name,
-                        converted_parameter,
-                    )
-                    for converted_name, converted_parameter in converted
-                ]
+                return super().convert_param(name, parameter, vp_stage=vp_stage)
 
         return McoreToHFWeightConverterQwen3_5
 

--- a/awex/models/qwen3_5.py
+++ b/awex/models/qwen3_5.py
@@ -15,14 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Qwen3.5 dense/MoE and multimodal weight-update support.
+"""Qwen3.5/Qwen3.6 dense, MoE, and multimodal weight-update support.
 
 Qwen3.5 combines Qwen3-style dense or expert MLPs with alternating full
-attention and Gated DeltaNet layers.  Its full-attention query projection also
-contains an output gate, so the Megatron ``linear_qkv`` tensor cannot be
-handled by the ordinary Qwen3 GQA splitter.  This module keeps the existing
-Qwen3 converters as the common path and only specializes the hybrid-attention
-and vision layouts.
+attention and Gated DeltaNet layers.  Qwen3.6 publishes the same Transformers
+``Qwen3_5*`` architecture and model-type identifiers and retains this weight
+contract, so both releases intentionally share this module.  Their full-
+attention query projection also contains an output gate, so the Megatron
+``linear_qkv`` tensor cannot be handled by the ordinary Qwen3 GQA splitter.
+This module keeps the existing Qwen3 converters as the common path and only
+specializes the hybrid-attention and vision layouts.
 
 The canonical names used by Awex are ``model.*`` for language weights and
 ``model.visual.*`` for the vision tower.  The language namespace is deliberately
@@ -53,8 +55,8 @@ class _Qwen3_5Layout:
     """Tensor-layout operations shared by the train-side converter.
 
     These methods operate only on tensors and model geometry.  Keeping them in
-    one helper class makes the Qwen3.5-specific packing rules explicit without
-    adding another set of generic converter functions to the package.
+    one helper class makes the shared Qwen3.5/Qwen3.6 packing rules explicit
+    without adding another set of generic converter functions to the package.
     """
 
     @staticmethod
@@ -64,7 +66,7 @@ class _Qwen3_5Layout:
 
     @classmethod
     def head_dim(cls, config) -> int:
-        """Resolve the explicit Qwen3.5 head width with a safe fallback."""
+        """Resolve the explicit Qwen3.5/Qwen3.6 head width safely."""
         config = cls.text_config(config)
         value = getattr(config, "head_dim", None)
         if value:
@@ -273,7 +275,7 @@ class _Qwen3_5Layout:
 
 
 class Qwen3_5ShardingStrategy(Qwen3VLShardingStrategy):
-    """TP/EP rules for Qwen3.5 language and vision parameters.
+    """TP/EP rules for Qwen3.5/Qwen3.6 language and vision parameters.
 
     Pipeline parallelism is represented by parameter ownership in Awex rather
     than another sharding enum, so this class only declares the tensor or expert
@@ -328,7 +330,7 @@ class Qwen3_5ShardingStrategy(Qwen3VLShardingStrategy):
 
 
 class SGlangToHFWeightConverterQwen3_5(SGlangToHFWeightConverterQwen3Moe):
-    """Normalize current SGLang Qwen3.5 target-model parameters.
+    """Normalize current SGLang Qwen3.5/Qwen3.6 target parameters.
 
     SGLang removes ``self_attn`` from full-attention module names and fuses the
     gated query/K/V weights into ``qkv_proj``.  The converter restores a stable
@@ -402,7 +404,7 @@ class _Qwen3_5McoreConverterFactory:
         base_converter = _build_mcore_converter_qwen3_moe()
 
         class McoreToHFWeightConverterQwen3_5(base_converter):
-            """Convert trainable Megatron Qwen3.5 language and vision weights.
+            """Convert trainable Megatron Qwen3.5/Qwen3.6 weights.
 
             Decoder PP layer ids continue through the existing Qwen3 converter,
             and expert id expansion plus EP offsets are inherited from the
@@ -545,7 +547,8 @@ class _Qwen3_5McoreConverterFactory:
                     target_suffix = self._vision_layer_mapping.get(suffix)
                     if target_suffix is None:
                         raise NotImplementedError(
-                            f"Unsupported Qwen3.5 vision layer parameter: {name}"
+                            "Unsupported Qwen3.5/Qwen3.6 vision layer "
+                            f"parameter: {name}"
                         )
                     if suffix in {
                         "self_attention.linear_qkv.weight",
@@ -553,7 +556,8 @@ class _Qwen3_5McoreConverterFactory:
                     }:
                         if self.vision_config is None:
                             raise ValueError(
-                                "vision_config is required for Qwen3.5 visual QKV"
+                                "vision_config is required for Qwen3.5/Qwen3.6 "
+                                "visual QKV"
                             )
                         from awex.converter.mcore_converter import (
                             convert_qkv_bias_along_tp_attention,
@@ -586,7 +590,7 @@ class _Qwen3_5McoreConverterFactory:
                         )
                     ]
                 raise NotImplementedError(
-                    f"Unsupported Qwen3.5 vision parameter: {name}"
+                    f"Unsupported Qwen3.5/Qwen3.6 vision parameter: {name}"
                 )
 
             @torch.no_grad()

--- a/awex/tests/test_qwen3_5.py
+++ b/awex/tests/test_qwen3_5.py
@@ -271,6 +271,56 @@ def test_native_vision_names_match_sglang(
 
 
 @pytest.mark.parametrize(
+    ("mcore_name", "canonical_name"),
+    [
+        (
+            "vision_model.patch_embed.proj.weight",
+            "model.visual.patch_embed.proj.weight",
+        ),
+        (
+            "vision_model.patch_embed.proj.bias",
+            "model.visual.patch_embed.proj.bias",
+        ),
+        ("vision_model.pos_embed.weight", "model.visual.pos_embed.weight"),
+        (
+            "vision_model.merger.patch_norm.weight",
+            "model.visual.merger.norm.weight",
+        ),
+        (
+            "vision_model.merger.patch_norm.bias",
+            "model.visual.merger.norm.bias",
+        ),
+        (
+            "vision_model.merger.linear_fc1.weight",
+            "model.visual.merger.linear_fc1.weight",
+        ),
+        (
+            "vision_model.merger.linear_fc1.bias",
+            "model.visual.merger.linear_fc1.bias",
+        ),
+        (
+            "vision_model.merger.linear_fc2.weight",
+            "model.visual.merger.linear_fc2.weight",
+        ),
+        (
+            "vision_model.merger.linear_fc2.bias",
+            "model.visual.merger.linear_fc2.bias",
+        ),
+    ],
+)
+def test_native_vision_direct_names(
+    mcore_name, canonical_name, vl_config, tf_config, rank_info
+):
+    """Cover the parameter names emitted by Megatron-Bridge Qwen3.5 VLM."""
+    converter = make_train_converter(vl_config, rank_info, tf_config)
+    parameter = torch.ones(4)
+
+    assert converter.convert_param(f"module.module.{mcore_name}", parameter) == [
+        (canonical_name, parameter)
+    ]
+
+
+@pytest.mark.parametrize(
     ("name", "expected_type", "expected_dim", "expected_shards"),
     [
         (

--- a/awex/tests/test_qwen3_5.py
+++ b/awex/tests/test_qwen3_5.py
@@ -1,0 +1,349 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""CPU regression tests for Qwen3.5 dense/MoE and VLM conversion."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from awex.models.qwen3_5 import (
+    _MCORE_CONVERTER_FACTORY,
+    CONFIG,
+    Qwen3_5ShardingStrategy,
+    SGlangToHFWeightConverterQwen3_5,
+    _Qwen3_5Layout,
+)
+from awex.models.registry import get_infer_weights_converter
+from awex.sharding.param_sharding import ShardingType
+
+
+@pytest.fixture
+def text_config():
+    return SimpleNamespace(
+        model_type="qwen3_5_moe_text",
+        architectures=["Qwen3_5MoeForCausalLM"],
+        hidden_size=8,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=2,
+        linear_num_key_heads=2,
+        linear_key_head_dim=2,
+        linear_num_value_heads=4,
+        linear_value_head_dim=2,
+        num_experts=4,
+        tie_word_embeddings=False,
+    )
+
+
+@pytest.fixture
+def vl_config(text_config):
+    return SimpleNamespace(
+        architectures=["Qwen3_5MoeForConditionalGeneration"],
+        text_config=text_config,
+        vision_config=SimpleNamespace(num_heads=2, hidden_size=4),
+        tie_word_embeddings=False,
+    )
+
+
+@pytest.fixture
+def tf_config():
+    return SimpleNamespace(
+        hidden_size=8,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=2,
+        num_layers=4,
+    )
+
+
+@pytest.fixture
+def rank_info():
+    return SimpleNamespace(
+        tp_rank=0,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        ep_rank=0,
+        ep_size=1,
+        ep_tp_rank=0,
+        ep_tp_size=1,
+        attn_tp_rank=0,
+        attn_tp_size=1,
+    )
+
+
+@pytest.fixture
+def infer_engine_config():
+    return SimpleNamespace(tp_size=1, ep_size=1, device_backend="cpu")
+
+
+def make_train_converter(config, rank_info, tf_config, **infer_conf):
+    converter_class = _MCORE_CONVERTER_FACTORY()
+    return converter_class(
+        config,
+        rank_info,
+        {"infer_atten_tp_size": 1, **infer_conf},
+        tf_config,
+    )
+
+
+def make_gated_qkv(text_config):
+    groups = []
+    queries_per_group = (
+        text_config.num_attention_heads // text_config.num_key_value_heads
+    )
+    query_rows = queries_per_group * text_config.head_dim
+    for group in range(text_config.num_key_value_heads):
+        groups.extend(
+            [
+                torch.full((query_rows, text_config.hidden_size), 10 + group),
+                torch.full((query_rows, text_config.hidden_size), 20 + group),
+                torch.full((text_config.head_dim, text_config.hidden_size), 30 + group),
+                torch.full((text_config.head_dim, text_config.hidden_size), 40 + group),
+            ]
+        )
+    return torch.cat(groups, dim=0)
+
+
+def test_single_module_registers_dense_moe_and_vlm_architectures():
+    assert {entry["model_name"] for entry in CONFIG} == {
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "Qwen3_5ForCausalLM",
+        "Qwen3_5MoeForCausalLM",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    ],
+)
+def test_registry_resolves_target_converter(
+    architecture, vl_config, rank_info, infer_engine_config
+):
+    converter = get_infer_weights_converter(
+        "sglang",
+        architecture,
+        vl_config,
+        rank_info,
+        infer_engine_config,
+    )
+    assert isinstance(converter, SGlangToHFWeightConverterQwen3_5)
+
+
+def test_gated_qkv_layout_is_grouped_by_inference_tp(text_config):
+    packed = _Qwen3_5Layout.pack_output_gated_qkv(
+        make_gated_qkv(text_config), text_config, infer_tp_size=2
+    )
+    rank0, rank1 = torch.chunk(packed, 2, dim=0)
+
+    assert rank0.shape == rank1.shape == (12, text_config.hidden_size)
+    torch.testing.assert_close(rank0[:2], torch.full_like(rank0[:2], 10))
+    torch.testing.assert_close(rank0[2:4], torch.full_like(rank0[2:4], 20))
+    torch.testing.assert_close(rank0[4:6], torch.full_like(rank0[4:6], 10))
+    torch.testing.assert_close(rank0[6:8], torch.full_like(rank0[6:8], 20))
+    torch.testing.assert_close(rank0[8:10], torch.full_like(rank0[8:10], 30))
+    torch.testing.assert_close(rank0[10:], torch.full_like(rank0[10:], 40))
+    torch.testing.assert_close(rank1[:2], torch.full_like(rank1[:2], 11))
+    torch.testing.assert_close(rank1[2:4], torch.full_like(rank1[2:4], 21))
+
+
+def test_main_gated_qkv_has_train_infer_parity(
+    vl_config, text_config, tf_config, rank_info, infer_engine_config
+):
+    train_converter = make_train_converter(vl_config, rank_info, tf_config)
+    infer_converter = SGlangToHFWeightConverterQwen3_5(
+        vl_config, infer_engine_config, rank_info
+    )
+    mcore_qkv = make_gated_qkv(text_config)
+
+    train = train_converter.convert_param(
+        "module.module.language_model.decoder.layers.0."
+        "self_attention.linear_qkv.weight",
+        mcore_qkv,
+    )
+    infer = infer_converter.convert_param("model.layers.0.qkv_proj.weight", train[0][1])
+
+    expected = "model.language_model.layers.0.self_attn.qkv_proj.weight"
+    assert train[0][0] == infer[0][0] == expected
+    torch.testing.assert_close(train[0][1], infer[0][1], rtol=0, atol=0)
+
+
+def test_gdn_conversion_matches_sglang_fused_names(vl_config, tf_config, rank_info):
+    converter = make_train_converter(vl_config, rank_info, tf_config)
+    # Q,K are 4 rows each; V,Z are 8 each; B,A are 4 each.
+    parameter = torch.arange(32 * 8, dtype=torch.float32).reshape(32, 8)
+
+    converted = converter.convert_param(
+        "module.module.language_model.decoder.layers.0.self_attention.in_proj.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.language_model.layers.0.linear_attn.in_proj_qkvz.weight",
+        "model.language_model.layers.0.linear_attn.in_proj_ba.weight",
+    ]
+    assert converted[0][1].shape[0] == 24
+    assert converted[1][1].shape[0] == 8
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "module.module.language_model.mtp.layers.0.eh_proj.weight",
+        "module.module.mtp.layers.0.mtp_model_layer.mlp.linear_fc1.weight",
+        "module.module.model.mtp.layers.0.final_layernorm.weight",
+    ],
+)
+def test_train_mtp_parameters_are_filtered(name, vl_config, tf_config, rank_info):
+    converter = make_train_converter(vl_config, rank_info, tf_config)
+
+    assert converter.convert_param(name, torch.ones(8, 8)) == []
+
+
+@pytest.mark.parametrize("name", ["mtp.fc.weight", "model.mtp.layers.0.norm.weight"])
+def test_infer_mtp_parameters_are_filtered(
+    name, vl_config, rank_info, infer_engine_config
+):
+    converter = SGlangToHFWeightConverterQwen3_5(
+        vl_config, infer_engine_config, rank_info
+    )
+
+    assert converter.convert_param(name, torch.ones(8, 8)) == []
+
+
+def test_pipeline_mapping_reindexes_main_layers(vl_config, tf_config, rank_info):
+    rank_info.pp_rank = 1
+    rank_info.pp_size = 2
+    converter = make_train_converter(
+        vl_config,
+        rank_info,
+        tf_config,
+        train_pp_stage_layer_id_map={(1, 0): {0: 3}},
+    )
+
+    main = converter.convert_param(
+        "module.module.language_model.decoder.layers.0."
+        "self_attention.linear_proj.weight",
+        torch.ones(8, 8),
+    )
+    assert main[0][0] == "model.language_model.layers.3.self_attn.o_proj.weight"
+
+
+def test_native_vision_names_match_sglang(
+    vl_config, tf_config, rank_info, infer_engine_config
+):
+    train_converter = make_train_converter(vl_config, rank_info, tf_config)
+    infer_converter = SGlangToHFWeightConverterQwen3_5(
+        vl_config, infer_engine_config, rank_info
+    )
+    parameter = torch.ones(4, 4)
+
+    train = train_converter.convert_param(
+        "module.module.vision_model.decoder.layers.2.self_attention.linear_proj.weight",
+        parameter,
+    )
+    infer = infer_converter.convert_param("visual.blocks.2.attn.proj.weight", parameter)
+
+    assert train[0][0] == infer[0][0] == ("model.visual.blocks.2.attn.proj.weight")
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_type", "expected_dim", "expected_shards"),
+    [
+        (
+            "model.language_model.layers.0.self_attn.qkv_proj.weight",
+            ShardingType.TP_SHARDING,
+            0,
+            2,
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.out_proj.weight",
+            ShardingType.TP_SHARDING,
+            1,
+            2,
+        ),
+        (
+            "model.language_model.layers.0.mlp.experts.0.down_proj.weight",
+            ShardingType.EP_SHARDING,
+            1,
+            2,
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.down_proj.weight",
+            ShardingType.TP_SHARDING,
+            1,
+            2,
+        ),
+        (
+            "model.visual.blocks.0.attn.qkv.weight",
+            ShardingType.TP_SHARDING,
+            0,
+            2,
+        ),
+    ],
+)
+def test_tp_ep_and_vision_sharding(
+    name, expected_type, expected_dim, expected_shards, rank_info
+):
+    rank_info.tp_size = 2
+    rank_info.attn_tp_size = 2
+    rank_info.ep_size = 2
+    strategy = Qwen3_5ShardingStrategy(
+        engine_name="sglang",
+        enable_dp_attention=False,
+        enable_dp_lm_head=False,
+        moe_dense_tp_size=2,
+        tp_size=2,
+        ep_size=2,
+        ep_tp_size=1,
+        rank_info=rank_info,
+        device_backend="cpu",
+    )
+
+    assert strategy.get_sharding_strategy(name) == (
+        expected_type,
+        expected_dim,
+        expected_shards,
+    )
+
+
+def test_ep_is_preserved_when_dense_tp_is_one(rank_info):
+    rank_info.ep_size = 2
+    strategy = Qwen3_5ShardingStrategy(
+        engine_name="sglang",
+        enable_dp_attention=False,
+        enable_dp_lm_head=False,
+        moe_dense_tp_size=1,
+        tp_size=1,
+        ep_size=2,
+        ep_tp_size=1,
+        rank_info=rank_info,
+        device_backend="cpu",
+    )
+
+    assert strategy.get_sharding_strategy(
+        "model.language_model.layers.0.mlp.experts.0.gate_proj.weight"
+    ) == (ShardingType.EP_SHARDING, 0, 2)

--- a/awex/tests/test_qwen3_5.py
+++ b/awex/tests/test_qwen3_5.py
@@ -186,7 +186,7 @@ def test_main_gated_qkv_has_train_infer_parity(
     )
     infer = infer_converter.convert_param("model.layers.0.qkv_proj.weight", train[0][1])
 
-    expected = "model.language_model.layers.0.self_attn.qkv_proj.weight"
+    expected = "model.layers.0.self_attn.qkv_proj.weight"
     assert train[0][0] == infer[0][0] == expected
     torch.testing.assert_close(train[0][1], infer[0][1], rtol=0, atol=0)
 
@@ -202,8 +202,8 @@ def test_gdn_conversion_matches_sglang_fused_names(vl_config, tf_config, rank_in
     )
 
     assert [name for name, _ in converted] == [
-        "model.language_model.layers.0.linear_attn.in_proj_qkvz.weight",
-        "model.language_model.layers.0.linear_attn.in_proj_ba.weight",
+        "model.layers.0.linear_attn.in_proj_qkvz.weight",
+        "model.layers.0.linear_attn.in_proj_ba.weight",
     ]
     assert converted[0][1].shape[0] == 24
     assert converted[1][1].shape[0] == 8
@@ -249,7 +249,34 @@ def test_pipeline_mapping_reindexes_main_layers(vl_config, tf_config, rank_info)
         "self_attention.linear_proj.weight",
         torch.ones(8, 8),
     )
-    assert main[0][0] == "model.language_model.layers.3.self_attn.o_proj.weight"
+    assert main[0][0] == "model.layers.3.self_attn.o_proj.weight"
+
+
+def test_text_and_vlm_configs_share_language_namespace(
+    vl_config, text_config, tf_config, rank_info, infer_engine_config
+):
+    """SGLang may expose either the wrapped VLM or its causal-LM submodule."""
+    name = "model.layers.0.linear_attn.out_proj.weight"
+    parameter = torch.ones(8, 8)
+    train_converter = make_train_converter(vl_config, rank_info, tf_config)
+    vl_converter = SGlangToHFWeightConverterQwen3_5(
+        vl_config, infer_engine_config, rank_info
+    )
+    text_converter = SGlangToHFWeightConverterQwen3_5(
+        text_config, infer_engine_config, rank_info
+    )
+
+    expected = [(name, parameter)]
+    assert (
+        train_converter.convert_param(
+            "module.module.language_model.decoder.layers.0."
+            "self_attention.out_proj.weight",
+            parameter,
+        )
+        == expected
+    )
+    assert vl_converter.convert_param(name, parameter) == expected
+    assert text_converter.convert_param(name, parameter) == expected
 
 
 def test_native_vision_names_match_sglang(
@@ -324,25 +351,25 @@ def test_native_vision_direct_names(
     ("name", "expected_type", "expected_dim", "expected_shards"),
     [
         (
-            "model.language_model.layers.0.self_attn.qkv_proj.weight",
+            "model.layers.0.self_attn.qkv_proj.weight",
             ShardingType.TP_SHARDING,
             0,
             2,
         ),
         (
-            "model.language_model.layers.0.linear_attn.out_proj.weight",
+            "model.layers.0.linear_attn.out_proj.weight",
             ShardingType.TP_SHARDING,
             1,
             2,
         ),
         (
-            "model.language_model.layers.0.mlp.experts.0.down_proj.weight",
+            "model.layers.0.mlp.experts.0.down_proj.weight",
             ShardingType.EP_SHARDING,
             1,
             2,
         ),
         (
-            "model.language_model.layers.0.mlp.shared_expert.down_proj.weight",
+            "model.layers.0.mlp.shared_expert.down_proj.weight",
             ShardingType.TP_SHARDING,
             1,
             2,
@@ -395,5 +422,5 @@ def test_ep_is_preserved_when_dense_tp_is_one(rank_info):
     )
 
     assert strategy.get_sharding_strategy(
-        "model.language_model.layers.0.mlp.experts.0.gate_proj.weight"
+        "model.layers.0.mlp.experts.0.gate_proj.weight"
     ) == (ShardingType.EP_SHARDING, 0, 2)

--- a/awex/tests/test_qwen3_5.py
+++ b/awex/tests/test_qwen3_5.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""CPU regression tests for Qwen3.5 dense/MoE and VLM conversion."""
+"""CPU regression tests for Qwen3.5/Qwen3.6 dense, MoE, and VLM conversion."""
 
 from types import SimpleNamespace
 
@@ -151,6 +151,98 @@ def test_registry_resolves_target_converter(
         infer_engine_config,
     )
     assert isinstance(converter, SGlangToHFWeightConverterQwen3_5)
+
+
+@pytest.mark.parametrize(
+    (
+        "architecture",
+        "root_model_type",
+        "text_model_type",
+        "hidden_size",
+        "num_hidden_layers",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "linear_num_value_heads",
+        "num_experts",
+    ),
+    [
+        (
+            "Qwen3_5ForConditionalGeneration",
+            "qwen3_5",
+            "qwen3_5_text",
+            5120,
+            64,
+            24,
+            4,
+            48,
+            None,
+        ),
+        (
+            "Qwen3_5MoeForConditionalGeneration",
+            "qwen3_5_moe",
+            "qwen3_5_moe_text",
+            2048,
+            40,
+            16,
+            2,
+            32,
+            256,
+        ),
+    ],
+)
+def test_qwen3_6_official_configs_reuse_qwen3_5_contract(
+    architecture,
+    root_model_type,
+    text_model_type,
+    hidden_size,
+    num_hidden_layers,
+    num_attention_heads,
+    num_key_value_heads,
+    linear_num_value_heads,
+    num_experts,
+    rank_info,
+    infer_engine_config,
+):
+    """Qwen3.6 Dense and MoE retain the public Qwen3.5 identifiers."""
+    text_config = SimpleNamespace(
+        model_type=text_model_type,
+        hidden_size=hidden_size,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        head_dim=256,
+        linear_num_key_heads=16,
+        linear_key_head_dim=128,
+        linear_num_value_heads=linear_num_value_heads,
+        linear_value_head_dim=128,
+        num_experts=num_experts,
+        tie_word_embeddings=False,
+    )
+    config = SimpleNamespace(
+        architectures=[architecture],
+        model_type=root_model_type,
+        text_config=text_config,
+        vision_config=SimpleNamespace(num_heads=16, hidden_size=1152),
+        tie_word_embeddings=False,
+    )
+
+    converter = get_infer_weights_converter(
+        "sglang",
+        architecture,
+        config,
+        rank_info,
+        infer_engine_config,
+    )
+
+    assert isinstance(converter, SGlangToHFWeightConverterQwen3_5)
+    assert converter.model_config is text_config
+    assert (
+        converter.convert_param(
+            "model.layers.0.linear_attn.A_log", torch.ones(linear_num_value_heads)
+        )[0][0]
+        == "model.layers.0.linear_attn.A_log"
+    )
+    assert converter.convert_param("mtp.norm.weight", torch.ones(hidden_size)) == []
 
 
 def test_gated_qkv_layout_is_grouped_by_inference_tp(text_config):


### PR DESCRIPTION
<!--
**Thanks for contributing to Awex.**

**If this is your first time opening a PR on Awex, you can refer to [CONTRIBUTING.md](https://github.com/inclusionAI/asystem-awex/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Awex** community has requirements on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/inclusionAI/asystem-awex/blob/main/CONTRIBUTING.md).
-->

## What does this PR do?

This PR adds AWEX weight-update support for Qwen3.5 and Qwen3.6 Dense, MoE, and multimodal models.

It reuses the existing Qwen3/Qwen3-VL infrastructure while adding support for hybrid Gated DeltaNet attention, gated QKV layouts, vision weights, and TP/PP/EP sharding. It also filters frozen MTP weights and normalizes training/inference parameter names for SGLang compatibility.

Qwen3.6 shares the same public architecture contract as Qwen3.5, so both are supported through the same implementation.

### Validation

- Added Dense, MoE, VLM, sharding, namespace, and MTP-filtering tests
- Ruff checks passed
- 100 passed

## Related issues

<!--
Is there any related issue? If this PR closes them you say say fix/closes:

- #xxxx0
- #xxxx1
- Fixes #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/inclusionAI/asystem-awex/issues/new/choose) describing the need to do so and update the document if necessary.

Delete section if not applicable.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
