### PR TITLE
feat: support Bailing V3 colocated weight updates

### DIFF
--- a/awex/models/ling_v3.py
+++ b/awex/models/ling_v3.py
@@ -1,0 +1,492 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import torch
+from transformers import PretrainedConfig
+
+from awex.converter.sglang_converter import (
+    LinearMLASGlangConverterMixin,
+    SGlangToHFWeightConverter,
+)
+from awex.converter.weights_converter import append_scale_inv, normalize_scale_inv_name
+from awex.models.ling import (
+    BailingMoeShardingStrategy,
+    _build_mcore_converter_bailing_moe,
+)
+from awex.sharding.param_sharding import LinearMLAShardingMixin, ShardingType
+
+
+def _cfg_value(config, name: str, default=None):
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def _is_kda_layer(
+    layer_idx: int,
+    layer_group_size: int | list[int],
+    num_hidden_layers: int | None = None,
+) -> bool:
+    if isinstance(layer_group_size, list):
+        return layer_group_size[layer_idx] == 1
+    if layer_group_size <= 1:
+        return False
+    if num_hidden_layers is not None:
+        full_group_layers = (num_hidden_layers // layer_group_size) * layer_group_size
+        if layer_idx >= full_group_layers:
+            return False
+    return (layer_idx + 1) % layer_group_size != 0
+
+
+def _kda_split_sections(config: PretrainedConfig, kind: str) -> list[int]:
+    head_dim = int(
+        getattr(config, "head_dim", None)
+        or getattr(config, "kv_channels", None)
+        or config.hidden_size // config.num_attention_heads
+    )
+    qk_dim = head_dim * int(config.num_attention_heads)
+    v_dim = int(getattr(config, "v_head_dim", head_dim)) * int(
+        config.num_attention_heads
+    )
+    if kind == "in_proj":
+        # mcore/SGLang fused order is [q, k, v, f, g].
+        return [qk_dim, qk_dim, v_dim, qk_dim, v_dim]
+    if kind == "conv1d":
+        return [qk_dim, qk_dim, v_dim]
+    raise ValueError(f"Unknown KDA split kind: {kind}")
+
+
+def _kda_fused_qkvbfg_split_sections(config: PretrainedConfig) -> list[int]:
+    q_dim, k_dim, v_dim, f_dim, g_dim = _kda_split_sections(config, "in_proj")
+    beta_dim = int(config.num_attention_heads)
+    # The current fused no-LoRA layout is [q, k, v, b, f, g]. The converter
+    # also accepts the legacy [q, k, v, f, g] layout below.
+    return [q_dim, k_dim, v_dim, beta_dim, f_dim, g_dim]
+
+
+def _kda_lora_a_split_sections(config: PretrainedConfig) -> list[int]:
+    head_dim = int(
+        getattr(config, "head_dim", None)
+        or getattr(config, "kv_channels", None)
+        or config.hidden_size // config.num_attention_heads
+    )
+    num_heads = int(config.num_attention_heads)
+    qk_dim = head_dim * num_heads
+    # The fused LoRA-A layout is [q, k, v, b, f_a, g_a]. The first four
+    # sections are column-parallel; f_a/g_a are repeated on every TP rank.
+    return [qk_dim, qk_dim, qk_dim, num_heads, head_dim, head_dim]
+
+
+def _local_sections(
+    total_sections: list[int], actual_dim0: int, tp_size: int
+) -> list[int]:
+    if sum(total_sections) == actual_dim0:
+        return total_sections
+    if tp_size > 1 and all(s % tp_size == 0 for s in total_sections):
+        sections = [s // tp_size for s in total_sections]
+        if sum(sections) == actual_dim0:
+            return sections
+    raise ValueError(
+        f"Cannot split fused KDA tensor with dim0={actual_dim0}; "
+        f"sections={total_sections}, tp_size={tp_size}"
+    )
+
+
+def _local_qkvbfg_a_sections(
+    total_sections: list[int], actual_dim0: int, tp_size: int
+) -> list[int]:
+    if sum(total_sections) == actual_dim0:
+        return total_sections
+    if tp_size > 1 and all(s % tp_size == 0 for s in total_sections[:4]):
+        sections = [s // tp_size for s in total_sections[:4]] + total_sections[4:]
+        if sum(sections) == actual_dim0:
+            return sections
+    raise ValueError(
+        f"Cannot split fused KDA lora-a tensor with dim0={actual_dim0}; "
+        f"sections={total_sections}, tp_size={tp_size}"
+    )
+
+
+class BailingV3ShardingStrategy(LinearMLAShardingMixin, BailingMoeShardingStrategy):
+    def get_sharding_strategy(self, parameter_name, **kwargs):
+        if (
+            "attention.f_a_proj.weight" in parameter_name
+            or "attention.g_a_proj.weight" in parameter_name
+        ):
+            return ShardingType.NO_SHARDING, 0, 1
+        return super().get_sharding_strategy(parameter_name, **kwargs)
+
+
+_KDA_PARAM_MARKERS = (
+    "self_attention.in_proj.weight",
+    "self_attention.conv1d.weight",
+    "self_attention.beta_proj.weight",
+    "self_attention.out_norm.weight",
+    "self_attention.out_proj.weight",
+    "self_attention.dt_bias",
+    "self_attention.A_log",
+)
+
+_MLA_PARAM_MARKERS = (
+    "self_attention.linear_q_proj.weight",
+    "self_attention.linear_q_down_proj.weight",
+    "self_attention.linear_q_up_proj",
+    "self_attention.linear_kv_down_proj.weight",
+    "self_attention.linear_kv_up_proj",
+    "self_attention.linear_gate.weight",
+    "self_attention.linear_proj.weight",
+)
+
+
+def _build_mcore_converter_bailing_moe_v3():
+    # Inference-only installations do not need Megatron to register this model.
+    from awex.converter.mcore_converter import LinearMLAMcoreConverterMixin
+
+    BaseBailingMoeConverter = _build_mcore_converter_bailing_moe()
+
+    class McoreToHFWeightConverterBailingMoeV3(
+        LinearMLAMcoreConverterMixin, BaseBailingMoeConverter
+    ):
+        def __init__(
+            self,
+            hf_config: PretrainedConfig,
+            rank_info,
+            infer_conf: dict,
+            tf_config,
+        ):
+            super().__init__(hf_config, rank_info, infer_conf, tf_config=tf_config)
+            self.layer_group_size = _cfg_value(
+                tf_config, "layer_group_size", None
+            ) or getattr(hf_config, "layer_group_size", 1)
+            self.num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
+
+        def _convert_lm_head_param(
+            self, name: str, parameter: torch.Tensor
+        ) -> list[tuple[str, torch.Tensor]]:
+            return [("lm_head.weight", parameter.to(torch.float32))]
+
+        def _convert_expert_bias_param(
+            self, name: str, parameter: torch.Tensor, layer_number: str
+        ) -> tuple[str, torch.Tensor]:
+            if "expert_bias" in name:
+                return ("mlp.gate.expert_bias", parameter.to(torch.float32))
+            return super()._convert_expert_bias_param(name, parameter, layer_number)
+
+        def _split_fused_kda(
+            self, parameter: torch.Tensor, kind: str
+        ) -> list[torch.Tensor]:
+            from megatron.core import parallel_state as mpu
+
+            from awex.converter.mcore_converter import get_full_tensor
+
+            # get_full_tensor all-gathers the train-TP chunks and concatenates
+            # them along dim0. For a Megatron fused column-parallel tensor each
+            # TP-rank chunk is itself laid out as [q/tp, k/tp, v/tp, ...], so
+            # the gathered tensor is [Q0 K0 V0 .. | Q1 K1 V1 .. | ...] and a
+            # naive split by the global sections misassigns every row past the
+            # first per-rank q block. De-interleave each TP chunk before
+            # concatenating the corresponding sections.
+            sections = _kda_split_sections(self.hf_config, kind)
+            tp = mpu.get_tensor_model_parallel_world_size()
+            rank = self.rank_info.tp_rank
+            if tp != self.rank_info.tp_size or not 0 <= rank < tp:
+                raise ValueError(
+                    "KDA train TP metadata does not match the process group: "
+                    f"rank={rank}, tp_size={self.rank_info.tp_size}, group_size={tp}"
+                )
+            full = get_full_tensor(parameter, dim=0)
+            if sum(sections) != full.shape[0] or any(s % tp != 0 for s in sections):
+                raise ValueError(
+                    "Cannot de-interleave fused KDA tensor: "
+                    f"shape={tuple(full.shape)}, sections={sections}, train_tp={tp}"
+                )
+
+            per_rank = [s // tp for s in sections]
+            gathered: list[list[torch.Tensor]] = [[] for _ in sections]
+            for chunk in torch.chunk(full, tp, dim=0):
+                for i, part in enumerate(torch.split(chunk, per_rank, dim=0)):
+                    gathered[i].append(part)
+            # Canonical metadata declares these tensors TP-sharded. Returning
+            # the global section on every rank would multiply its declared
+            # size by train TP and send the wrong regions to inference ranks.
+            return [
+                torch.cat(parts, dim=0).chunk(tp, dim=0)[rank].contiguous()
+                for parts in gathered
+            ]
+
+        def _convert_kda_attention_param(
+            self, name: str, parameter: torch.Tensor, layer_number: str
+        ) -> list[tuple[str, torch.Tensor]]:
+            direct_mapping = {
+                "self_attention.beta_proj.weight": "attention.b_proj.weight",
+                "self_attention.out_norm.weight": "attention.o_norm.weight",
+                "self_attention.out_proj.weight": "attention.o_proj.weight",
+                "self_attention.dt_bias": "attention.dt_bias",
+                "self_attention.A_log": "attention.A_log",
+            }
+            for src, target in direct_mapping.items():
+                if src in name:
+                    tensor = (
+                        parameter.reshape(-1) if target.endswith("A_log") else parameter
+                    )
+                    return [(target, tensor)]
+
+            if "self_attention.in_proj.weight" in name:
+                names = [
+                    "attention.q_proj.weight",
+                    "attention.k_proj.weight",
+                    "attention.v_proj.weight",
+                    "attention.f_proj.weight",
+                    "attention.g_proj.weight",
+                ]
+                return list(zip(names, self._split_fused_kda(parameter, "in_proj")))
+
+            if "self_attention.conv1d.weight" in name:
+                names = [
+                    "attention.q_conv1d.weight",
+                    "attention.k_conv1d.weight",
+                    "attention.v_conv1d.weight",
+                ]
+                return list(zip(names, self._split_fused_kda(parameter, "conv1d")))
+
+            raise NotImplementedError(f"Unsupported BailingMoeV3 KDA parameter: {name}")
+
+        def _convert_mla_attention_param(
+            self, name: str, parameter: torch.Tensor, layer_number: str
+        ) -> list[tuple[str, torch.Tensor]]:
+            if "self_attention.linear_gate.weight" in name:
+                return [("attention.g_proj.weight", parameter)]
+            return super()._convert_mla_attention_param(name, parameter, layer_number)
+
+        def _convert_attention_param(
+            self, name: str, parameter: torch.Tensor, layer_number: str
+        ) -> list[tuple[str, torch.Tensor]]:
+            if any(marker in name for marker in _KDA_PARAM_MARKERS):
+                return self._convert_kda_attention_param(name, parameter, layer_number)
+            if any(marker in name for marker in _MLA_PARAM_MARKERS):
+                return self._convert_mla_attention_param(name, parameter, layer_number)
+
+            layer_idx = int(layer_number)
+            if _is_kda_layer(layer_idx, self.layer_group_size, self.num_hidden_layers):
+                return self._convert_kda_attention_param(name, parameter, layer_number)
+            return self._convert_mla_attention_param(name, parameter, layer_number)
+
+        @torch.no_grad()
+        def convert_param(
+            self, name: str, parameter: torch.Tensor, vp_stage: int = None
+        ) -> list[tuple[str, torch.Tensor]]:
+            converted = super().convert_param(name, parameter, vp_stage=vp_stage)
+            # BailingMoeV3 exposes ``word_embeddings`` rather than
+            # ``embed_tokens`` in the inference model.
+            return [
+                (
+                    "model.word_embeddings.weight"
+                    if hf_name == "model.embed_tokens.weight"
+                    else hf_name,
+                    hf_param,
+                )
+                for hf_name, hf_param in converted
+            ]
+
+    return McoreToHFWeightConverterBailingMoeV3
+
+
+class SGlangToHFWeightConverterBailingMoeV3(
+    LinearMLASGlangConverterMixin,
+    SGlangToHFWeightConverter,
+):
+    def _split_fused_kda(
+        self, parameter: torch.Tensor, kind: str
+    ) -> list[torch.Tensor]:
+        total_sections = _kda_split_sections(self.model_config, kind)
+        sections = _local_sections(total_sections, parameter.shape[0], self.tp_size)
+        return list(torch.split(parameter, sections, dim=0))
+
+    def _split_fused_qkvbfg(
+        self, parameter: torch.Tensor
+    ) -> tuple[list[str], list[torch.Tensor]]:
+        rel_names = [
+            "attention.q_proj.weight",
+            "attention.k_proj.weight",
+            "attention.v_proj.weight",
+            "attention.b_proj.weight",
+            "attention.f_proj.weight",
+            "attention.g_proj.weight",
+        ]
+        rel_sections = _kda_fused_qkvbfg_split_sections(self.model_config)
+        try:
+            local_rel_sections = _local_sections(
+                rel_sections, parameter.shape[0], self.tp_size
+            )
+        except ValueError:
+            legacy_names = [
+                "attention.q_proj.weight",
+                "attention.k_proj.weight",
+                "attention.v_proj.weight",
+                "attention.f_proj.weight",
+                "attention.g_proj.weight",
+            ]
+            try:
+                return legacy_names, self._split_fused_kda(parameter, "in_proj")
+            except ValueError as legacy_error:
+                raise ValueError(
+                    "Cannot split fused_qkvbfg_proj as rel [q,k,v,b,f,g] "
+                    "or legacy [q,k,v,f,g] layout"
+                ) from legacy_error
+        return rel_names, list(torch.split(parameter, local_rel_sections, dim=0))
+
+    def _split_fused_qkvbfg_a(self, parameter: torch.Tensor) -> list[torch.Tensor]:
+        total_sections = _kda_lora_a_split_sections(self.model_config)
+        sections = _local_qkvbfg_a_sections(
+            total_sections, parameter.shape[0], self.tp_size
+        )
+        return list(torch.split(parameter, sections, dim=0))
+
+    def _split_fused_fg_b(self, parameter: torch.Tensor) -> list[torch.Tensor]:
+        if parameter.shape[0] != 2:
+            raise ValueError(
+                "Expected fused_fg_b_proj to have leading batch dim 2, "
+                f"got shape={tuple(parameter.shape)}"
+            )
+        return [parameter[0], parameter[1]]
+
+    def _convert_layer_norm_param(
+        self, name: str, parameter: torch.Tensor, layer_number: str
+    ) -> list[tuple[str, torch.Tensor]]:
+        base_name, has_scale_inv = normalize_scale_inv_name(name)
+        if base_name in {
+            "attention.o_norm.weight",
+            "attention.kv_a_layernorm.weight",
+            "attention.q_a_layernorm.weight",
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+        }:
+            return [(append_scale_inv(base_name, has_scale_inv), parameter)]
+        return super()._convert_layer_norm_param(name, parameter, layer_number)
+
+    def _convert_attention_param(
+        self, name: str, parameter: torch.Tensor, layer_number: str
+    ) -> list[tuple[str, torch.Tensor]]:
+        base_name, has_scale_inv = normalize_scale_inv_name(name)
+
+        if base_name == "attention.fused_qkvbfg_proj.weight":
+            names, tensors = self._split_fused_qkvbfg(parameter)
+            return [
+                (append_scale_inv(target, has_scale_inv), tensor)
+                for target, tensor in zip(names, tensors)
+            ]
+
+        if base_name == "attention.fused_qkvbfg_a_proj.weight":
+            names = [
+                "attention.q_proj.weight",
+                "attention.k_proj.weight",
+                "attention.v_proj.weight",
+                "attention.b_proj.weight",
+                "attention.f_a_proj.weight",
+                "attention.g_a_proj.weight",
+            ]
+            return [
+                (append_scale_inv(target, has_scale_inv), tensor)
+                for target, tensor in zip(names, self._split_fused_qkvbfg_a(parameter))
+            ]
+
+        if base_name == "attention.fused_fg_b_proj.weight":
+            names = [
+                "attention.f_b_proj.weight",
+                "attention.g_b_proj.weight",
+            ]
+            return [
+                (append_scale_inv(target, has_scale_inv), tensor)
+                for target, tensor in zip(names, self._split_fused_fg_b(parameter))
+            ]
+
+        if base_name == "attention.qkv_conv1d.weight":
+            names = [
+                "attention.q_conv1d.weight",
+                "attention.k_conv1d.weight",
+                "attention.v_conv1d.weight",
+            ]
+            return [
+                (append_scale_inv(target, has_scale_inv), tensor)
+                for target, tensor in zip(
+                    names, self._split_fused_kda(parameter, "conv1d")
+                )
+            ]
+
+        if base_name == "attention.o_proj.weight":
+            layer_idx = int(layer_number)
+            layer_group_size = getattr(self.model_config, "layer_group_size", 1)
+            num_hidden_layers = getattr(self.model_config, "num_hidden_layers", None)
+            target = (
+                "attention.o_proj.weight"
+                if _is_kda_layer(layer_idx, layer_group_size, num_hidden_layers)
+                else "attention.dense.weight"
+            )
+            return [(append_scale_inv(target, has_scale_inv), parameter)]
+
+        direct = {
+            "attention.q_proj.weight",
+            "attention.k_proj.weight",
+            "attention.v_proj.weight",
+            "attention.f_proj.weight",
+            "attention.g_proj.weight",
+            "attention.b_proj.weight",
+            "attention.f_a_proj.weight",
+            "attention.g_a_proj.weight",
+            "attention.f_b_proj.weight",
+            "attention.g_b_proj.weight",
+            "attention.q_conv1d.weight",
+            "attention.k_conv1d.weight",
+            "attention.v_conv1d.weight",
+            "attention.o_norm.weight",
+            "attention.dt_bias",
+            "attention.A_log",
+        }
+        if base_name in direct:
+            tensor = (
+                parameter.reshape(-1) if base_name == "attention.A_log" else parameter
+            )
+            return [(append_scale_inv(base_name, has_scale_inv), tensor)]
+
+        return super()._convert_attention_param(name, parameter, layer_number)
+
+    @torch.no_grad()
+    def convert_param(
+        self, name: str, parameter: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        if name == "model.word_embeddings.weight":
+            return [("model.word_embeddings.weight", parameter)]
+        converted = super().convert_param(name, parameter)
+        return [
+            (
+                "model.word_embeddings.weight"
+                if hf_name == "model.embed_tokens.weight"
+                else hf_name,
+                hf_param,
+            )
+            for hf_name, hf_param in converted
+        ]
+
+
+CONFIG = {
+    "model_name": "BailingMoeV3ForCausalLM",
+    "sharding_strategy": BailingV3ShardingStrategy,
+    "mcore_converter": _build_mcore_converter_bailing_moe_v3,
+    "sglang_converter": SGlangToHFWeightConverterBailingMoeV3,
+}

--- a/awex/reader/nccl_reader.py
+++ b/awex/reader/nccl_reader.py
@@ -43,6 +43,29 @@ from awex.util.tensor_util import reconstruct_ipc_weights
 logger = logging.getLogger(__name__)
 
 
+def _wait_colocate_write_finished(
+    meta_server_client,
+    write_finished_key: str,
+    weights_update_group,
+) -> None:
+    """Wait until all colocated readers observe the writer's release signal."""
+
+    meta_server_client.get_object(write_finished_key, 1024**3)
+    dist.barrier(
+        group=weights_update_group,
+        device_ids=[device_util.current_device()],
+    )
+    # Keys normally include the local device, but multiple processes can still
+    # share one when CUDA_VISIBLE_DEVICES remaps every process-local GPU to 0.
+    # Cleanup is idempotent, so each rank deletes its own key only after every
+    # rank has observed its corresponding writer signal.
+    meta_server_client.delete_if_exists(write_finished_key)
+    dist.barrier(
+        group=weights_update_group,
+        device_ids=[device_util.current_device()],
+    )
+
+
 class NCCLWorkerWeightsReader(WorkerWeightsReader):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -487,7 +510,11 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
         if device_util.get_device_type() == "cuda":
             torch.cuda.empty_cache()
         write_finished_key = f"write_finished{key_suffix}"
-        self.meta_server_client.get_object_then_delete(write_finished_key)
+        _wait_colocate_write_finished(
+            self.meta_server_client,
+            write_finished_key,
+            self.weights_update_group,
+        )
         logger.info(
             f"Finished updating weights in colocate mode for rank {self.transfer_rank}"
         )

--- a/awex/tests/test_ling_v3.py
+++ b/awex/tests/test_ling_v3.py
@@ -1,0 +1,614 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from awex.meta.meta_resolver import ParamMetaResolver
+from awex.models import get_infer_weights_converter, get_sharding_strategy
+from awex.models.registry import get_train_weights_converter
+from awex.sharding.param_sharding import ShardingType
+from awex.sharding.rank_info import RankInfo
+from awex.transfer.transfer_plan import TransferPlanBuilder
+
+
+@pytest.fixture
+def train_tp(monkeypatch):
+    from megatron.core import parallel_state as mpu
+
+    monkeypatch.setattr(mpu, "get_tensor_model_parallel_world_size", lambda: 1)
+    return mpu
+
+
+def _make_rank_info() -> RankInfo:
+    return RankInfo(
+        tp_rank=0,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        dp_size=1,
+        dp_rank=0,
+        ep_rank=0,
+        ep_size=1,
+        ep_tp_rank=0,
+        ep_tp_size=1,
+        attn_tp_rank=0,
+        attn_tp_size=1,
+        attn_dp_rank=0,
+        world_size=1,
+        global_rank=0,
+        local_rank=0,
+        engine_rank=0,
+        is_infer=False,
+    )
+
+
+def _make_bailing_v3_config() -> PretrainedConfig:
+    cfg = PretrainedConfig()
+    cfg.architectures = ["BailingMoeV3ForCausalLM"]
+    cfg.quantization_config = {}
+    cfg.num_hidden_layers = 4
+    cfg.hidden_size = 8
+    cfg.num_attention_heads = 2
+    cfg.num_key_value_heads = 2
+    cfg.head_dim = 2
+    cfg.v_head_dim = 2
+    cfg.layer_group_size = 4
+    cfg.num_experts = 4
+    return cfg
+
+
+def test_bailing_v3_train_converter_accepts_tf_config(train_tp):
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = {"infer_atten_tp_size": 1}
+    tf_config = SimpleNamespace(layer_group_size=4)
+
+    converter = get_train_weights_converter(
+        "mcore",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+        tf_config=tf_config,
+    )
+
+    assert converter.tf_config is tf_config
+    assert converter.layer_group_size == 4
+
+
+def test_bailing_v3_train_converter_splits_kda_attention(monkeypatch, train_tp):
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = {"infer_atten_tp_size": 1}
+    tf_config = SimpleNamespace(layer_group_size=4)
+    converter = get_train_weights_converter(
+        "mcore",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+        tf_config=tf_config,
+    )
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor",
+        lambda tensor, dim=0: tensor,
+    )
+
+    parameter = torch.arange(40, dtype=torch.float32).reshape(20, 2)
+    converted = converter.convert_param(
+        "decoder.layers.0.self_attention.in_proj.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.q_proj.weight",
+        "model.layers.0.attention.k_proj.weight",
+        "model.layers.0.attention.v_proj.weight",
+        "model.layers.0.attention.f_proj.weight",
+        "model.layers.0.attention.g_proj.weight",
+    ]
+    for idx, (_, tensor) in enumerate(converted):
+        torch.testing.assert_close(tensor, parameter[idx * 4 : (idx + 1) * 4])
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1])
+def test_bailing_v3_train_converter_deinterleaves_tp_kda_sections(
+    monkeypatch, train_tp, tp_rank
+):
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    rank_info.tp_size = 2
+    rank_info.tp_rank = tp_rank
+    converter = get_train_weights_converter(
+        "mcore",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        {"infer_atten_tp_size": 2},
+        tf_config=SimpleNamespace(layer_group_size=4),
+    )
+
+    # Each train-TP chunk is locally fused as [Q, K, V, F, G]. A plain
+    # all-gather therefore produces [Q0,K0,...,Q1,K1,...]. Reconstruct the
+    # global [Q0,Q1,K0,K1,...] sections before inference-side sharding.
+    tp_gathered = torch.cat(
+        [
+            torch.full((2, 1), 10 * rank + section, dtype=torch.float32)
+            for rank in range(2)
+            for section in range(5)
+        ],
+        dim=0,
+    )
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor",
+        lambda tensor, dim=0: tp_gathered,
+    )
+    monkeypatch.setattr(train_tp, "get_tensor_model_parallel_world_size", lambda: 2)
+
+    sections = converter._split_fused_kda(torch.empty(0), "in_proj")
+
+    expected = [
+        torch.tensor(
+            [[10 * tp_rank + section], [10 * tp_rank + section]],
+            dtype=torch.float32,
+        )
+        for section in range(5)
+    ]
+    assert len(sections) == len(expected)
+    for actual, reference in zip(sections, expected):
+        torch.testing.assert_close(actual, reference)
+
+
+def test_bailing_v3_train_converter_rejects_invalid_tp_kda_layout(
+    monkeypatch, train_tp
+):
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    rank_info.tp_size = 3
+    converter = get_train_weights_converter(
+        "mcore",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        {"infer_atten_tp_size": 1},
+        tf_config=SimpleNamespace(layer_group_size=4),
+    )
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor",
+        lambda tensor, dim=0: torch.empty(20, 1),
+    )
+    monkeypatch.setattr(train_tp, "get_tensor_model_parallel_world_size", lambda: 3)
+
+    with pytest.raises(ValueError, match="Cannot de-interleave fused KDA tensor"):
+        converter._split_fused_kda(torch.empty(0), "in_proj")
+
+
+def test_bailing_v3_sglang_converter_splits_fused_kda_attention():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = SimpleNamespace(tp_size=1, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.arange(40, dtype=torch.float32).reshape(20, 2)
+    converted = converter.convert_param(
+        "model.layers.0.attention.fused_qkvbfg_proj.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.q_proj.weight",
+        "model.layers.0.attention.k_proj.weight",
+        "model.layers.0.attention.v_proj.weight",
+        "model.layers.0.attention.f_proj.weight",
+        "model.layers.0.attention.g_proj.weight",
+    ]
+    for idx, (_, tensor) in enumerate(converted):
+        torch.testing.assert_close(tensor, parameter[idx * 4 : (idx + 1) * 4])
+
+
+def test_bailing_v3_sglang_converter_splits_rel_fused_kda_attention_with_beta():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = SimpleNamespace(tp_size=1, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.arange(44, dtype=torch.float32).reshape(22, 2)
+    converted = converter.convert_param(
+        "model.layers.0.attention.fused_qkvbfg_proj.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.q_proj.weight",
+        "model.layers.0.attention.k_proj.weight",
+        "model.layers.0.attention.v_proj.weight",
+        "model.layers.0.attention.b_proj.weight",
+        "model.layers.0.attention.f_proj.weight",
+        "model.layers.0.attention.g_proj.weight",
+    ]
+    starts_and_ends = [(0, 4), (4, 8), (8, 12), (12, 14), (14, 18), (18, 22)]
+    for (_, tensor), (start, end) in zip(converted, starts_and_ends):
+        torch.testing.assert_close(tensor, parameter[start:end])
+
+
+def test_bailing_v3_sglang_converter_splits_local_qkv_conv_tp():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    rank_info.tp_size = 2
+    infer_conf = SimpleNamespace(tp_size=2, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    converted = converter.convert_param(
+        "model.layers.0.attention.qkv_conv1d.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.q_conv1d.weight",
+        "model.layers.0.attention.k_conv1d.weight",
+        "model.layers.0.attention.v_conv1d.weight",
+    ]
+    for idx, (_, tensor) in enumerate(converted):
+        torch.testing.assert_close(tensor, parameter[idx * 2 : (idx + 1) * 2])
+
+
+def test_bailing_v3_sglang_converter_splits_fused_qkvbfg_a_tp():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    rank_info.tp_size = 2
+    infer_conf = SimpleNamespace(tp_size=2, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.arange(22, dtype=torch.float32).reshape(11, 2)
+    converted = converter.convert_param(
+        "model.layers.0.attention.fused_qkvbfg_a_proj.weight",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.q_proj.weight",
+        "model.layers.0.attention.k_proj.weight",
+        "model.layers.0.attention.v_proj.weight",
+        "model.layers.0.attention.b_proj.weight",
+        "model.layers.0.attention.f_a_proj.weight",
+        "model.layers.0.attention.g_a_proj.weight",
+    ]
+    offsets = [0, 2, 4, 6, 7, 9]
+    sections = [2, 2, 2, 1, 2, 2]
+    for (_, tensor), offset, section in zip(converted, offsets, sections):
+        torch.testing.assert_close(tensor, parameter[offset : offset + section])
+
+
+def test_bailing_v3_sglang_converter_splits_fused_fg_b():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = SimpleNamespace(tp_size=1, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    converted = converter.convert_param(
+        "model.layers.0.attention.fused_fg_b_proj.weight_scale_inv",
+        parameter,
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.attention.f_b_proj.weight_scale_inv",
+        "model.layers.0.attention.g_b_proj.weight_scale_inv",
+    ]
+    torch.testing.assert_close(converted[0][1], parameter[0])
+    torch.testing.assert_close(converted[1][1], parameter[1])
+
+
+def test_bailing_v3_sglang_converter_normalizes_word_embeddings_and_a_log():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = SimpleNamespace(tp_size=1, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    embedding = torch.randn(4, 3)
+    assert converter.convert_param("model.word_embeddings.weight", embedding) == [
+        ("model.word_embeddings.weight", embedding)
+    ]
+
+    a_log = torch.randn(1, 1, 2, 1)
+    converted = converter.convert_param("model.layers.0.attention.A_log", a_log)
+    assert converted[0][0] == "model.layers.0.attention.A_log"
+    torch.testing.assert_close(converted[0][1], a_log.squeeze())
+
+
+def test_bailing_v3_sglang_converter_maps_o_proj_by_layer_type():
+    cfg = _make_bailing_v3_config()
+    rank_info = _make_rank_info()
+    infer_conf = SimpleNamespace(tp_size=1, ep_size=1)
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        rank_info,
+        infer_conf,
+    )
+
+    parameter = torch.randn(4, 4)
+
+    kda_converted = converter.convert_param(
+        "model.layers.0.attention.o_proj.weight",
+        parameter,
+    )
+    assert kda_converted == [("model.layers.0.attention.o_proj.weight", parameter)]
+
+    mla_converted = converter.convert_param(
+        "model.layers.3.attention.o_proj.weight",
+        parameter,
+    )
+    assert mla_converted == [("model.layers.3.attention.dense.weight", parameter)]
+
+    scale_converted = converter.convert_param(
+        "model.layers.3.attention.o_proj.weight_scale_inv",
+        parameter,
+    )
+    assert scale_converted == [
+        ("model.layers.3.attention.dense.weight_scale_inv", parameter)
+    ]
+
+
+def test_bailing_v3_sharding_strategy_handles_kda_and_mla_params():
+    rank_info = _make_rank_info()
+    rank_info.tp_size = 2
+    strategy_cls = get_sharding_strategy("BailingMoeV3ForCausalLM")
+    strategy = strategy_cls(
+        engine_name="sglang",
+        enable_dp_attention=False,
+        enable_dp_lm_head=False,
+        moe_dense_tp_size=2,
+        tp_size=2,
+        ep_size=1,
+        ep_tp_size=1,
+        rank_info=rank_info,
+    )
+
+    assert strategy.get_sharding_strategy(
+        "model.layers.0.attention.fused_qkvbfg_proj.weight"
+    ) == (ShardingType.TP_SHARDING, 0, 2)
+    assert strategy.get_sharding_strategy(
+        "model.layers.0.attention.qkv_conv1d.weight"
+    ) == (ShardingType.TP_SHARDING, 0, 2)
+    assert strategy.get_sharding_strategy(
+        "model.layers.0.attention.f_a_proj.weight"
+    ) == (ShardingType.NO_SHARDING, 0, 1)
+    assert strategy.get_sharding_strategy(
+        "model.layers.0.attention.g_a_proj.weight"
+    ) == (ShardingType.NO_SHARDING, 0, 1)
+    assert strategy.get_sharding_strategy(
+        "model.layers.0.attention.f_b_proj.weight"
+    ) == (ShardingType.TP_SHARDING, 0, 2)
+    assert strategy.get_sharding_strategy(
+        "model.layers.3.attention.kv_a_proj_with_mqa.weight"
+    ) == (ShardingType.NO_SHARDING, 0, 1)
+
+
+def test_bailing_v3_model_registration_does_not_import_megatron():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import importlib.abc
+import sys
+
+# AWEX's package entry point already imports its writer. Exercise the model
+# registry independently of that existing package-wide dependency.
+import awex
+from awex.models.registry import import_model_configs
+for module in list(sys.modules):
+    if module == 'megatron' or module.startswith('megatron.') or module in (
+        'awex.models.ling_v3', 'awex.converter.mcore_converter'
+    ):
+        del sys.modules[module]
+
+class WithoutMegatron(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'megatron' or fullname.startswith('megatron.'):
+            raise ModuleNotFoundError(fullname)
+
+sys.meta_path.insert(0, WithoutMegatron())
+import_model_configs.cache_clear()
+config = import_model_configs()['BailingMoeV3ForCausalLM']
+from awex.models.ling_v3 import BailingV3ShardingStrategy
+assert config['sharding_strategy'] is BailingV3ShardingStrategy
+""",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("kind", ["in_proj", "conv1d"])
+def test_bailing_v3_tp4_to_tp8_transfer_matches_canonical_sections(
+    monkeypatch, train_tp, kind
+):
+    from awex.models.ling_v3 import _kda_split_sections
+
+    cfg = _make_bailing_v3_config()
+    cfg.num_attention_heads = 8
+    cfg.num_key_value_heads = 8
+    cfg.v_head_dim = 4  # Unequal Q/K and V sections also need correct offsets.
+    sections = _kda_split_sections(cfg, kind)
+    canonical = [
+        torch.arange(size * 2, dtype=torch.float32).reshape(size, 2) + index * 1000
+        for index, size in enumerate(sections)
+    ]
+    local_train = [
+        torch.cat([tensor.chunk(4)[rank] for tensor in canonical]) for rank in range(4)
+    ]
+    monkeypatch.setattr(train_tp, "get_tensor_model_parallel_world_size", lambda: 4)
+    monkeypatch.setattr(
+        "awex.converter.mcore_converter.get_full_tensor",
+        lambda tensor, dim=0: torch.cat(local_train, dim=dim),
+    )
+
+    class Resolver(ParamMetaResolver):
+        def __init__(self, engine, shards):
+            super().__init__(cfg)
+            self.engine = engine
+            self.shards = shards
+
+        def get_model_arch_name(self):
+            return "BailingMoeV3ForCausalLM"
+
+        def get_parameters_meta(self):
+            return self._build_params_meta()
+
+        def _get_params_raw_meta(self):
+            return self.shards
+
+        def _get_sharding_info(self, name, rank_info, param_meta):
+            strategy = get_sharding_strategy(self.get_model_arch_name())(
+                engine_name=self.engine,
+                enable_dp_attention=False,
+                enable_dp_lm_head=False,
+                moe_dense_tp_size=rank_info.tp_size,
+                tp_size=rank_info.tp_size,
+                ep_size=1,
+                ep_tp_size=1,
+                rank_info=rank_info,
+            )
+            return strategy.get_sharding_strategy(name)
+
+    def metadata(rank_info, weights):
+        return {
+            "rank_info": rank_info,
+            "params_meta": [
+                {
+                    "name": name,
+                    "numel": param.numel(),
+                    "shape": tuple(param.shape),
+                    "dtype": param.dtype,
+                }
+                for name, param in weights.items()
+            ],
+        }
+
+    training, train_meta, inference, infer_meta = [], [], [], []
+    for rank in range(4):
+        info = _make_rank_info()
+        info.tp_rank = info.attn_tp_rank = info.global_rank = rank
+        info.tp_size = info.attn_tp_size = info.world_size = 4
+        converter = get_train_weights_converter(
+            "mcore",
+            "BailingMoeV3ForCausalLM",
+            cfg,
+            info,
+            {"infer_atten_tp_size": 8},
+            tf_config=SimpleNamespace(layer_group_size=4),
+        )
+        weights = dict(
+            converter.convert_param(
+                f"decoder.layers.0.self_attention.{kind}.weight", local_train[rank]
+            )
+        )
+        training.append(weights)
+        train_meta.append(metadata(info, weights))
+
+    names = list(training[0])
+    for rank in range(8):
+        info = _make_rank_info()
+        info.is_infer = True
+        info.tp_rank = info.attn_tp_rank = info.global_rank = rank
+        info.tp_size = info.attn_tp_size = info.world_size = 8
+        weights = {
+            name: torch.full_like(tensor.chunk(8)[rank], float("nan"))
+            for name, tensor in zip(names, canonical)
+        }
+        inference.append(weights)
+        infer_meta.append(metadata(info, weights))
+
+    train_params = Resolver("mcore", train_meta).get_parameters_meta()
+    infer_params = Resolver("sglang", infer_meta).get_parameters_meta()
+    assert [p.global_shape for p in train_params] == [tuple(t.shape) for t in canonical]
+    operations = TransferPlanBuilder(
+        infer_world_size=8, train_world_size=4
+    ).build_weights_mapping_operations(infer_params, train_params)
+    for operation in operations:
+        name = operation.send_shard_meta.name
+        src = training[operation.send_shard_meta.global_rank][name]
+        dst = inference[operation.recv_shard_meta.global_rank][name]
+        dst[operation.inf_slices].copy_(src[operation.train_slices])
+    for rank, weights in enumerate(inference):
+        for name, tensor in zip(names, canonical):
+            torch.testing.assert_close(weights[name], tensor.chunk(8)[rank])
+
+
+def test_bailing_v3_sglang_single_head_a_log_retains_vector_shape():
+    cfg = _make_bailing_v3_config()
+    info = _make_rank_info()
+    info.tp_size = 2
+    converter = get_infer_weights_converter(
+        "sglang",
+        "BailingMoeV3ForCausalLM",
+        cfg,
+        info,
+        SimpleNamespace(tp_size=2, ep_size=1),
+    )
+    converted = converter.convert_param(
+        "model.layers.0.attention.A_log", torch.ones(1, 1, 1, 1)
+    )
+    assert converted[0][1].shape == (1,)

--- a/awex/tests/test_nccl_reader.py
+++ b/awex/tests/test_nccl_reader.py
@@ -1,0 +1,127 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event, Lock
+
+import pytest
+
+from awex.meta.meta_server import MetaServer, MetaServerClient
+from awex.reader import nccl_reader
+
+
+class _MetaServerClient:
+    def __init__(self):
+        self.get_calls = []
+        self.deleted_keys = []
+
+    def get_object(self, key, timeout=0, default_value=None):
+        self.get_calls.append((key, timeout, default_value))
+        return True
+
+    def delete_if_exists(self, key):
+        self.deleted_keys.append(key)
+
+
+def test_wait_colocate_write_finished_reads_before_idempotent_cleanup(monkeypatch):
+    barrier_calls = []
+
+    monkeypatch.setattr(nccl_reader.device_util, "current_device", lambda: 3)
+    monkeypatch.setattr(
+        nccl_reader.dist,
+        "barrier",
+        lambda group=None, device_ids=None: barrier_calls.append((group, device_ids)),
+    )
+
+    rank0_meta = _MetaServerClient()
+    rank3_meta = _MetaServerClient()
+
+    nccl_reader._wait_colocate_write_finished(rank0_meta, "rank0_key", "pg")
+    nccl_reader._wait_colocate_write_finished(rank3_meta, "rank3_key", "pg")
+
+    assert rank0_meta.get_calls == [("rank0_key", 1024**3, None)]
+    assert rank3_meta.get_calls == [("rank3_key", 1024**3, None)]
+    assert rank0_meta.deleted_keys == ["rank0_key"]
+    assert rank3_meta.deleted_keys == ["rank3_key"]
+    assert barrier_calls == [
+        ("pg", [3]),
+        ("pg", [3]),
+        ("pg", [3]),
+        ("pg", [3]),
+    ]
+
+
+@pytest.mark.parametrize("shared_key", [False, True])
+def test_wait_colocate_write_finished_concurrent_readers(monkeypatch, shared_key):
+    """Exercise real HTTP reads/deletes with a delayed reader and CPU barriers."""
+    num_readers = 4
+    barrier = Barrier(num_readers, timeout=5)
+    first_read = Event()
+    lock = Lock()
+    observed = set()
+    deleted = set()
+    keys = ["shared" if shared_key else f"device_{rank}" for rank in range(num_readers)]
+    server = MetaServer("127.0.0.1", 0)
+    server.start()
+    monkeypatch.setattr(nccl_reader.device_util, "current_device", lambda: 0)
+    monkeypatch.setattr(nccl_reader.dist, "barrier", lambda **kwargs: barrier.wait())
+
+    class Client(MetaServerClient):
+        def __init__(self, rank):
+            super().__init__(server.host, server.port)
+            self.rank = rank
+
+        def get_object(self, key, timeout=0, default_value=None):
+            if self.rank == num_readers - 1:
+                assert first_read.wait(timeout=5)
+            value = super().get_object(key, timeout=3, default_value=default_value)
+            with lock:
+                observed.add(self.rank)
+            if self.rank == 0:
+                first_read.set()
+            return value
+
+        def delete_if_exists(self, key):
+            with lock:
+                # A destructive first read would strand the delayed reader
+                # when several inference processes share a completion key.
+                assert len(observed) == num_readers
+            super().delete_if_exists(key)
+            with lock:
+                deleted.add(self.rank)
+
+    def wait(rank):
+        try:
+            nccl_reader._wait_colocate_write_finished(Client(rank), keys[rank], "pg")
+            # No reader can return before every rank has finished cleanup.
+            with lock:
+                assert len(deleted) == num_readers
+        except BaseException:
+            barrier.abort()
+            raise
+
+    try:
+        writer = MetaServerClient(server.host, server.port)
+        for key in set(keys):
+            writer.put_object(key, True)
+        with ThreadPoolExecutor(max_workers=num_readers) as executor:
+            futures = [executor.submit(wait, rank) for rank in range(num_readers)]
+            for future in futures:
+                future.result(timeout=10)
+        assert all(not writer.has_key(key) for key in set(keys))
+    finally:
+        server.stop()


### PR DESCRIPTION
## What does this PR do?

Add BailingMoeV3 (Ling V3) weight conversion for Megatron training and SGLang inference, including KDA projections/convolution, gated MLA, fused inference layouts and canonical sharding metadata.

KDA projections are fused within each training TP shard. After gathering `[Q0,K0,... | Q1,K1,...]`, the converter reconstructs each projection and returns the local training shard. This prevents TP-sharded metadata from describing a replicated full projection as a larger tensor when resharding, for example, training TP4 to inference TP8.

For colocated updates, all readers now observe their `write_finished` signal before idempotent cleanup. This prevents a fast reader from deleting a shared completion key before another reader sees it. The existing v0.8.1 transport and non-contiguous staging are unchanged.

## Related issues

Companion to the Bailing V3 RL integration in AReaL; model/SFT support is already in [AReaL #1598](https://github.com/areal-project/AReaL/pull/1598).

## Validation

- 55 CPU tests passed: V3 converter/registry, canonical metadata, actual TP4-to-TP8 transfer-plan construction, and concurrent HTTP MetaServer completion reads for shared and per-device keys.
- Tests use real Torch tensors and cached Megatron Core 0.16.0 source. Collective communication is mocked; this is not a NCCL test.
- Ruff checks and wheel build passed; packaged changed-source hashes match the worktree.
- Multi-GPU NCCL exchange, checkpoint comparison after transfer and two-step RL remain untested. Kept as a draft pending that integration validation.

## Does this PR introduce any user-facing change?

Adds the `BailingMoeV3ForCausalLM` converter/sharding registration. Existing converter interfaces and metadata keys remain unchanged. Completion cleanup adds synchronization between readers; use the same AWEX revision across readers in a job.

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?
